### PR TITLE
The change we discussed earlier.

### DIFF
--- a/python/netlink/route/link.py
+++ b/python/netlink/route/link.py
@@ -152,6 +152,15 @@ class Link(netlink.Object):
         self.inet = inet.InetLink(self)
         self.af = {'inet' : self.inet }
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is None:
+            self.change()
+        else:
+            return false
+
     @classmethod
     def from_capi(cls, obj):
         return cls(capi.link2obj(obj))


### PR DESCRIPTION
With this change you can still set do modifications of
Links and then to change to pass the changes to the
kernel. But it additionally enables you to interact
with this part of libnl-python in a more pythonic
way. Instead of:

```
eth0 = links['eth0']
eth0.mtu = 5000
eth0.change()
```

you can do:

```
with links['eth0'] as eth0:
    eth0.mtu = 5000
```
