### PR TITLE
Re-adding #defines for __aligned_be64 for older kernels

### DIFF
--- a/include/linux/netfilter/nfnetlink_log.h
+++ b/include/linux/netfilter/nfnetlink_log.h
@@ -5,6 +5,10 @@
  * and not any kind of function definitions.  It is shared between kernel and
  * userspace.  Don't put kernel specific stuff in here */
 
+#ifndef __aligned_be64
+#define __aligned_be64 u_int64_t __attribute__((aligned(8)))
+#endif
+
 #include <linux/types.h>
 #include <linux/netfilter/nfnetlink.h>
 

--- a/include/linux/netfilter/nfnetlink_queue.h
+++ b/include/linux/netfilter/nfnetlink_queue.h
@@ -4,6 +4,10 @@
 #include <linux/types.h>
 #include <linux/netfilter/nfnetlink.h>
 
+#ifndef __aligned_be64
+#define __aligned_be64 u_int64_t __attribute__((aligned(8)))
+#endif
+
 enum nfqnl_msg_types {
 	NFQNL_MSG_PACKET,		/* packet from kernel to userspace */
 	NFQNL_MSG_VERDICT,		/* verdict from userspace to kernel */


### PR DESCRIPTION
Recent local kernel header updates removed #define of aligned_be64 (now __aligned_be64) from nfnetlink_log.h and nfnetlink_queue.h.  This change re-introduces the #define statements.
