### PR TITLE
Included defs.h so DISABLE_PTHREADS is visible.

### DIFF
--- a/include/netlink-local.h
+++ b/include/netlink-local.h
@@ -33,6 +33,8 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
+#include <defs.h>
+
 #ifndef SOL_NETLINK
 #define SOL_NETLINK 270
 #endif


### PR DESCRIPTION
pthread usage was introduced into include/netlink-local.h with correct ifndef surrounding the code.  The defs.h file was not included so the ifndefs did not work if configured with --disable-pthreads.
