### PR TITLE
netfilter: expectation NAT direction is 32 bit attribute

### DIFF
--- a/include/netlink/netfilter/exp.h
+++ b/include/netlink/netfilter/exp.h
@@ -92,9 +92,9 @@ extern int  nfnl_exp_set_fn(struct nfnl_exp *, void *);
 extern int  nfnl_exp_test_fn(const struct nfnl_exp *);
 extern const char * nfnl_exp_get_fn(const struct nfnl_exp *);
 
-extern void nfnl_exp_set_nat_dir(struct nfnl_exp *, uint8_t);
+extern void nfnl_exp_set_nat_dir(struct nfnl_exp *, uint32_t);
 extern int  nfnl_exp_test_nat_dir(const struct nfnl_exp *);
-extern uint8_t nfnl_exp_get_nat_dir(const struct nfnl_exp *);
+extern uint32_t nfnl_exp_get_nat_dir(const struct nfnl_exp *);
 
 // The int argument specifies which nfnl_exp_dir (expect, master, mask or nat)
 // Expectation objects only use orig, not reply

--- a/lib/netfilter/exp.c
+++ b/lib/netfilter/exp.c
@@ -70,7 +70,7 @@ static struct nla_policy exp_proto_policy[CTA_PROTO_MAX+1] = {
 };
 
 static struct nla_policy exp_nat_policy[CTA_EXPECT_NAT_MAX+1] = {
-	[CTA_EXPECT_NAT_DIR]	= { .type = NLA_U8 },
+	[CTA_EXPECT_NAT_DIR]	= { .type = NLA_U32 },
 	[CTA_EXPECT_NAT_TUPLE]	= { .type = NLA_NESTED },
 };
 
@@ -195,7 +195,7 @@ static int exp_parse_nat(struct nfnl_exp *exp, struct nlattr *attr)
 		return err;
 
 	if (tb[CTA_EXPECT_NAT_DIR])
-		nfnl_exp_set_nat_dir(exp, nla_get_u8(tb[CTA_EXPECT_NAT_DIR]));
+		nfnl_exp_set_nat_dir(exp, nla_get_u32(tb[CTA_EXPECT_NAT_DIR]));
 
 	if (tb[CTA_EXPECT_NAT_TUPLE]) {
 		err = exp_parse_tuple(exp, NFNL_EXP_TUPLE_NAT, tb[CTA_EXPECT_NAT_TUPLE]);
@@ -416,7 +416,7 @@ static int nfnl_exp_build_nat(struct nl_msg *msg, const struct nfnl_exp *exp)
 	nat = nla_nest_start(msg, CTA_EXPECT_NAT);
 
 	if (nfnl_exp_test_nat_dir(exp)) {
-		NLA_PUT_U8(msg, CTA_EXPECT_NAT_DIR,
+		NLA_PUT_U32(msg, CTA_EXPECT_NAT_DIR,
 				nfnl_exp_get_nat_dir(exp));
 	}
 

--- a/lib/netfilter/exp_obj.c
+++ b/lib/netfilter/exp_obj.c
@@ -589,7 +589,7 @@ const char * nfnl_exp_get_fn(const struct nfnl_exp *exp)
 	return exp->exp_fn;
 }
 
-void nfnl_exp_set_nat_dir(struct nfnl_exp *exp, uint8_t nat_dir)
+void nfnl_exp_set_nat_dir(struct nfnl_exp *exp, uint32_t nat_dir)
 {
 	exp->exp_nat_dir = nat_dir;
 	exp->ce_mask |= EXP_ATTR_NAT_DIR;
@@ -600,7 +600,7 @@ int nfnl_exp_test_nat_dir(const struct nfnl_exp *exp)
 	return !!(exp->ce_mask & EXP_ATTR_NAT_DIR);
 }
 
-uint8_t nfnl_exp_get_nat_dir(const struct nfnl_exp *exp)
+uint32_t nfnl_exp_get_nat_dir(const struct nfnl_exp *exp)
 {
 	return exp->exp_nat_dir;
 }

--- a/src/nf-exp-add.c
+++ b/src/nf-exp-add.c
@@ -86,6 +86,12 @@ int main(int argc, char *argv[])
 			ARG_MASK_SPORT,
 			ARG_MASK_DST,
 			ARG_MASK_DPORT,
+            ARG_NAT_PROTO,
+            ARG_NAT_SRC,
+            ARG_NAT_SPORT,
+            ARG_NAT_DST,
+            ARG_NAT_DPORT,
+            ARG_NAT_DIR,
 			ARG_TIMEOUT,
 			ARG_HELPER_NAME,
 			ARG_REPLACE,
@@ -112,6 +118,12 @@ int main(int argc, char *argv[])
 			{ "mask-sport", 1, 0, ARG_MASK_SPORT },
 			{ "mask-dst", 1, 0, ARG_MASK_DST },
 			{ "mask-dport", 1, 0, ARG_MASK_DPORT },
+            { "nat-proto", 1, 0, ARG_NAT_PROTO },
+            { "nat-src", 1, 0, ARG_NAT_SRC },
+            { "nat-sport", 1, 0, ARG_NAT_SPORT },
+            { "nat-dst", 1, 0, ARG_NAT_DST },
+            { "nat-dport", 1, 0, ARG_NAT_DPORT },
+            { "nat-dir", 1, 0, ARG_NAT_DIR },
 			{ "family", 1, 0, 'F' },
 			{ "timeout", 1, 0, ARG_TIMEOUT },
 			{ "helper", 1, 0, ARG_HELPER_NAME },
@@ -147,6 +159,12 @@ int main(int argc, char *argv[])
 		case ARG_MASK_SPORT: nl_cli_exp_parse_src_port(exp, NFNL_EXP_TUPLE_MASK, optarg); break;
 		case ARG_MASK_DST: nl_cli_exp_parse_dst(exp, NFNL_EXP_TUPLE_MASK, optarg); break;
 		case ARG_MASK_DPORT: nl_cli_exp_parse_dst_port(exp, NFNL_EXP_TUPLE_MASK, optarg); break;
+        case ARG_NAT_PROTO: nl_cli_exp_parse_l4protonum(exp, NFNL_EXP_TUPLE_NAT, optarg); break;
+        case ARG_NAT_SRC: nl_cli_exp_parse_src(exp, NFNL_EXP_TUPLE_NAT, optarg); break;
+        case ARG_NAT_SPORT: nl_cli_exp_parse_src_port(exp, NFNL_EXP_TUPLE_NAT, optarg); break;
+        case ARG_NAT_DST: nl_cli_exp_parse_dst(exp, NFNL_EXP_TUPLE_NAT, optarg); break;
+        case ARG_NAT_DPORT: nl_cli_exp_parse_dst_port(exp, NFNL_EXP_TUPLE_NAT, optarg); break;
+        case ARG_NAT_DIR: nl_cli_exp_parse_nat_dir(exp, optarg); break;
 		case 'F': nl_cli_exp_parse_family(exp, optarg); break;
 		case ARG_TIMEOUT: nl_cli_exp_parse_timeout(exp, optarg); break;
 		case ARG_HELPER_NAME: nl_cli_exp_parse_helper_name(exp, optarg); break;


### PR DESCRIPTION
Corrects Netlink Attribute type for expectation NAT direction from 8 to 32 bits.
