### PR TITLE
netfilter: expectation NAT direction is 32 bit attribute

### DIFF
--- a/include/netlink/netfilter/exp.h
+++ b/include/netlink/netfilter/exp.h
@@ -92,9 +92,9 @@ extern int  nfnl_exp_set_fn(struct nfnl_exp *, void *);
 extern int  nfnl_exp_test_fn(const struct nfnl_exp *);
 extern const char * nfnl_exp_get_fn(const struct nfnl_exp *);
 
-extern void nfnl_exp_set_nat_dir(struct nfnl_exp *, uint32_t);
+extern void nfnl_exp_set_nat_dir(struct nfnl_exp *, uint8_t);
 extern int  nfnl_exp_test_nat_dir(const struct nfnl_exp *);
-extern uint32_t nfnl_exp_get_nat_dir(const struct nfnl_exp *);
+extern uint8_t nfnl_exp_get_nat_dir(const struct nfnl_exp *);
 
 // The int argument specifies which nfnl_exp_dir (expect, master, mask or nat)
 // Expectation objects only use orig, not reply

--- a/lib/netfilter/exp_obj.c
+++ b/lib/netfilter/exp_obj.c
@@ -589,7 +589,7 @@ const char * nfnl_exp_get_fn(const struct nfnl_exp *exp)
 	return exp->exp_fn;
 }
 
-void nfnl_exp_set_nat_dir(struct nfnl_exp *exp, uint32_t nat_dir)
+void nfnl_exp_set_nat_dir(struct nfnl_exp *exp, uint8_t nat_dir)
 {
 	exp->exp_nat_dir = nat_dir;
 	exp->ce_mask |= EXP_ATTR_NAT_DIR;
@@ -600,7 +600,7 @@ int nfnl_exp_test_nat_dir(const struct nfnl_exp *exp)
 	return !!(exp->ce_mask & EXP_ATTR_NAT_DIR);
 }
 
-uint32_t nfnl_exp_get_nat_dir(const struct nfnl_exp *exp)
+uint8_t nfnl_exp_get_nat_dir(const struct nfnl_exp *exp)
 {
 	return exp->exp_nat_dir;
 }


### PR DESCRIPTION
Corrects netlink attribute type of expectation NAT direction from 8 to 32 bits.
