### PR TITLE
Perform no operation on nl_object_free(NULL).

### DIFF
--- a/lib/object.c
+++ b/lib/object.c
@@ -165,7 +165,12 @@ int nl_object_update(struct nl_object *dst, struct nl_object *src)
  */
 void nl_object_free(struct nl_object *obj)
 {
-	struct nl_object_ops *ops = obj_ops(obj);
+	struct nl_object_ops *ops;
+
+	if (!obj)
+		return;
+
+	ops = obj_ops(obj);
 
 	if (obj->ce_refcnt > 0)
 		NL_DBG(1, "Warning: Freeing object in use...\n");


### PR DESCRIPTION
Passing a NULL pointer would cause a NULL pointer dereference within
`nl_object_free()`.
Returning early on `NULL` pointer is the behavior `free(3)` and other
`nl*_free()` functions.

Is this change correct or `nl_object_free()` is written this way on purpose?
