### PR TITLE
Call to_msg_fill_raw when defined to_msg_fill is NULL

### DIFF
--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -214,17 +214,23 @@ int rtnl_tc_msg_build(struct rtnl_tc *tc, int type, int flags,
 	    NLA_PUT_STRING(msg, TCA_KIND, tc->tc_kind);
 
 	ops = rtnl_tc_get_ops(tc);
-	if (ops && ops->to_msg_fill) {
+	if (ops && (ops->to_msg_fill || ops->to_msg_fill_raw)) {
 		struct nlattr *opts;
 		void *data = rtnl_tc_data(tc);
 
-		if (!(opts = nla_nest_start(msg, TCA_OPTIONS)))
-			goto nla_put_failure;
+		if (ops->to_msg_fill) {
+      if (!(opts = nla_nest_start(msg, TCA_OPTIONS)))
+				goto nla_put_failure;
 
-		if ((err = ops->to_msg_fill(tc, data, msg)) < 0)
-			goto nla_put_failure;
+			if ((err = ops->to_msg_fill(tc, data, msg)) < 0)
+				goto nla_put_failure;
 
-		nla_nest_end(msg, opts);
+			nla_nest_end(msg, opts);
+
+		}else{
+			if ((err = ops->to_msg_fill_raw(tc, data, msg)) < 0)
+				goto nla_put_failure;
+		}
 	}
 
 	*result = msg;


### PR DESCRIPTION
netem qdisc uses to_msg_fill_raw to build netlink packet. So far, this
was not called from anywhere.

Example creating a netem qdisc before and after the change:

[root@testbox libnl]# NLCB=debug ./netem
-- Debug: Sent Message:
--------------------------   BEGIN NETLINK MESSAGE ---------------------------
  [NETLINK HEADER] 16 octets
    .nlmsg_len = 48
    .type = 36 <route/qdisc::new>
    .flags = 1029 <REQUEST,ACK,ATOMIC>
    .seq = 1376894544
    .port = 17877
  [PAYLOAD] 20 octets
    00 00 00 00 02 00 00 00 00 00 01 80 01 00 01 00 ................
    00 00 00 00                                     ....
  [ATTR 01] 6 octets
    6e 65 74 65 6d 00                               netem.
  [PADDING] 2 octets
    00 00                                           ..
---------------------------  END NETLINK MESSAGE ---------------------------
-- Debug: Received Message:
--------------------------   BEGIN NETLINK MESSAGE ---------------------------
  [NETLINK HEADER] 16 octets
    .nlmsg_len = 68
    .type = 2 <ERROR>
    .flags = 0 <>
    .seq = 1376894544
    .port = 17877
  [ERRORMSG] 20 octets
    .error = -22 "Invalid argument"
  [ORIGINAL MESSAGE] 16 octets
    .nlmsg_len = 16
    .type = 36 <0x24>
    .flags = 1029 <REQUEST,ACK,ATOMIC>
    .seq = 1376894544
    .port = 17877
---------------------------  END NETLINK MESSAGE ---------------------------
-- Error received: Invalid argument
-- Original message: type=0x24 length=48 flags=<REQUEST,ACK,ATOMIC>
sequence-nr=1376894544 pid=17877
RC -7
[root@testbox libnl]# NLCB=debug ./netem
-- Debug: Sent Message:
--------------------------   BEGIN NETLINK MESSAGE ---------------------------
  [NETLINK HEADER] 16 octets
    .nlmsg_len = 76
    .type = 36 <route/qdisc::new>
    .flags = 1029 <REQUEST,ACK,ATOMIC>
    .seq = 1376895147
    .port = 26541
  [PAYLOAD] 20 octets
    00 00 00 00 02 00 00 00 00 00 01 80 01 00 01 00 ................
    00 00 00 00                                     ....
  [ATTR 01] 6 octets
    6e 65 74 65 6d 00                               netem.
  [PADDING] 2 octets
    00 00                                           ..
  [ATTR 02] 24 octets
    00 00 00 00 a0 86 01 00 00 00 00 80 00 00 00 00 ................
    00 00 00 00 00 00 00 00                         ........
---------------------------  END NETLINK MESSAGE ---------------------------
-- Debug: Received Message:
--------------------------   BEGIN NETLINK MESSAGE ---------------------------
  [NETLINK HEADER] 16 octets
    .nlmsg_len = 36
    .type = 2 <ERROR>
    .flags = 0 <>
    .seq = 1376895147
    .port = 26541
  [ERRORMSG] 20 octets
    .error = 0 "Success"
  [ORIGINAL MESSAGE] 16 octets
    .nlmsg_len = 16
    .type = 36 <0x24>
    .flags = 1029 <REQUEST,ACK,ATOMIC>
    .seq = 1376895147
    .port = 26541
---------------------------  END NETLINK MESSAGE  ---------------------------
RC 0
[root@testbox libnl]# tc qdisc show
qdisc htb 1: dev eth0 root refcnt 2 r2q 10 default 0 direct_packets_stat 21115
qdisc netem 8001: dev eth0 parent 1:1 limit 100000 loss 50%
qdisc htb 1: dev eth1 root refcnt 2 r2q 10 default 0 direct_packets_stat 0
