### PR TITLE
Remove extra memset from __nlmsg_alloc

### DIFF
--- a/lib/msg.c
+++ b/lib/msg.c
@@ -275,8 +275,6 @@ static struct nl_msg *__nlmsg_alloc(size_t len)
 	if (!nm->nm_nlh)
 		goto errout;
 
-	memset(nm->nm_nlh, 0, sizeof(struct nlmsghdr));
-
 	nm->nm_protocol = -1;
 	nm->nm_size = len;
 	nm->nm_nlh->nlmsg_len = nlmsg_total_size(0);


### PR DESCRIPTION
A few lines above nm->nm_nlh is already allocated with calloc, the
allocated memory has at least sizeof(struct nlmsghdr).

Signed-off-by: Olaf Hering olaf@aepfle.de
