### PR TITLE
python: fix typo

### DIFF
--- a/python/netlink/core.py
+++ b/python/netlink/core.py
@@ -449,7 +449,7 @@ class ObjIterator(object):
         return capi.nl_cache_get_next(self._nl_object)
 
     def next(self):
-        return self.__next__(self)
+        return self.__next__()
 
     def __next__(self):
         if self._end:


### PR DESCRIPTION
self.**next**() bound method does not take an extra argument.

Signed-off-by: Hiroaki KAWAI kawai@stratosphere.co.jp
