### PR TITLE
[bugfix] Avoid calling free() with a bad pointer

### DIFF
--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -94,7 +94,6 @@ static void xfrm_sp_free_data(struct nl_object *c)
 
 	if(sp->sec_ctx)
 	{
-		free (sp->sec_ctx->ctx);
 		free (sp->sec_ctx);
 	}
 


### PR DESCRIPTION
sp->sec_ctx->ctx is a zero-length member, so it's already allocated
