### PR TITLE
netlink/netlink.h: fix build error with the musl C library

### DIFF
--- a/include/netlink/netlink.h
+++ b/include/netlink/netlink.h
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
netlink/netlink.h: As the poll() man page recommends include <poll.h> instead of <sys/poll.h>. This removes an error when building libnl with the musl C library.
