### PR TITLE
src: log errors from platform

### DIFF
--- a/lib/cache_mngr.c
+++ b/lib/cache_mngr.c
@@ -391,8 +391,13 @@ int nl_cache_mngr_poll(struct nl_cache_mngr *mngr, int timeout)
 	NL_DBG(3, "Cache manager %p, poll() fd %d\n", mngr, fds.fd);
 	ret = poll(&fds, 1, timeout);
 	NL_DBG(3, "Cache manager %p, poll() returned %d\n", mngr, ret);
-	if (ret < 0)
+	if (ret < 0) {
+		char buf[64];
+
+		NL_DBG(4, "nl_cache_mngr_poll(%p): poll() failed with %d (%s)\n",
+			mngr, errno, strerror_r(errno, buf, sizeof(buf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	/* No events, return */
 	if (ret == 0)

--- a/lib/nl.c
+++ b/lib/nl.c
@@ -98,6 +98,7 @@ int nl_connect(struct nl_sock *sk, int protocol)
 	int err, flags = 0;
 	int errsv;
 	socklen_t addrlen;
+	char buf[64];
 
 #ifdef SOCK_CLOEXEC
 	flags |= SOCK_CLOEXEC;
@@ -109,7 +110,8 @@ int nl_connect(struct nl_sock *sk, int protocol)
 	sk->s_fd = socket(AF_NETLINK, SOCK_RAW | flags, protocol);
 	if (sk->s_fd < 0) {
 		errsv = errno;
-		NL_DBG(4, "nl_connect(%p): socket() failed with %d\n", sk, errsv);
+		NL_DBG(4, "nl_connect(%p): socket() failed with %d (%s)\n", sk, errsv,
+			strerror_r(errsv, buf, sizeof(buf)));
 		err = -nl_syserr2nlerr(errsv);
 		goto errout;
 	}
@@ -143,7 +145,8 @@ int nl_connect(struct nl_sock *sk, int protocol)
 				NL_DBG(4, "nl_connect(%p): local port %u already in use. Retry.\n", sk, (unsigned) port);
 				_nl_socket_used_ports_set(used_ports, port);
 			} else {
-				NL_DBG(4, "nl_connect(%p): bind() for port %u failed with %d\n", sk, (unsigned) port, errsv);
+				NL_DBG(4, "nl_connect(%p): bind() for port %u failed with %d (%s)\n",
+					sk, (unsigned) port, errsv, strerror_r(errsv, buf, sizeof(buf)));
 				_nl_socket_used_ports_release_all(used_ports);
 				err = -nl_syserr2nlerr(errsv);
 				goto errout;
@@ -155,7 +158,8 @@ int nl_connect(struct nl_sock *sk, int protocol)
 			   sizeof(sk->s_local));
 		if (err != 0) {
 			errsv = errno;
-			NL_DBG(4, "nl_connect(%p): bind() failed with %d\n", sk, errsv);
+			NL_DBG(4, "nl_connect(%p): bind() failed with %d (%s)\n",
+				sk, errsv, strerror_r(errsv, buf, sizeof(buf)));
 			err = -nl_syserr2nlerr(errsv);
 			goto errout;
 		}
@@ -165,6 +169,8 @@ int nl_connect(struct nl_sock *sk, int protocol)
 	err = getsockname(sk->s_fd, (struct sockaddr *) &sk->s_local,
 			  &addrlen);
 	if (err < 0) {
+		NL_DBG(4, "nl_connect(%p): getsockname() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
 		err = -nl_syserr2nlerr(errno);
 		goto errout;
 	}
@@ -254,8 +260,13 @@ int nl_sendto(struct nl_sock *sk, void *buf, size_t size)
 
 	ret = sendto(sk->s_fd, buf, size, 0, (struct sockaddr *)
 		     &sk->s_peer, sizeof(sk->s_peer));
-	if (ret < 0)
+	if (ret < 0) {
+		char errbuf[64];
+
+		NL_DBG(4, "nl_sendto(%p): sendto() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, errbuf, sizeof(errbuf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	return ret;
 }
@@ -312,8 +323,13 @@ int nl_sendmsg(struct nl_sock *sk, struct nl_msg *msg, struct msghdr *hdr)
 			return ret;
 
 	ret = sendmsg(sk->s_fd, hdr, 0);
-	if (ret < 0)
+	if (ret < 0) {
+		char errbuf[64];
+
+		NL_DBG(4, "nl_sendmsg(%p): sendmsg() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, errbuf, sizeof(errbuf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	NL_DBG(4, "sent %d bytes\n", ret);
 	return ret;
@@ -671,10 +687,15 @@ retry:
 		goto abort;
 	}
 	if (n < 0) {
+		char errbuf[64];
+
 		if (errno == EINTR) {
 			NL_DBG(3, "recvmsg() returned EINTR, retrying\n");
 			goto retry;
 		}
+
+		NL_DBG(4, "nl_sendmsg(%p): nl_recv() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, errbuf, sizeof(errbuf)));
 		retval = -nl_syserr2nlerr(errno);
 		goto abort;
 	}
@@ -926,6 +947,11 @@ continue_reading:
 					goto out;
 				}
 			} else if (e->error) {
+				char buf[64];
+
+				NL_DBG(4, "recvmsgs(%p): RTNETLINK responded with %d (%s)\n",
+					sk, -e->error, strerror_r(-e->error, buf, sizeof(buf)));
+
 				/* Error message reported back from kernel. */
 				if (cb->cb_err) {
 					err = cb->cb_err(&nla, e,

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -433,7 +433,11 @@ int nl_socket_add_memberships(struct nl_sock *sk, int group, ...)
 		err = setsockopt(sk->s_fd, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
 						 &group, sizeof(group));
 		if (err < 0) {
+			char buf[64];
+
 			va_end(ap);
+			NL_DBG(4, "nl_socket_add_memberships(%p): setsockopt() failed with %d (%s)\n",
+				sk, errno, strerror_r(errno, buf, sizeof(buf)));
 			return -nl_syserr2nlerr(errno);
 		}
 
@@ -481,7 +485,11 @@ int nl_socket_drop_memberships(struct nl_sock *sk, int group, ...)
 		err = setsockopt(sk->s_fd, SOL_NETLINK, NETLINK_DROP_MEMBERSHIP,
 						 &group, sizeof(group));
 		if (err < 0) {
+			char buf[64];
+
 			va_end(ap);
+			NL_DBG(4, "nl_socket_drop_memberships(%p): setsockopt() failed with %d (%s)\n",
+				sk, errno, strerror_r(errno, buf, sizeof(buf)));
 			return -nl_syserr2nlerr(errno);
 		}
 
@@ -575,8 +583,13 @@ int nl_socket_set_nonblocking(const struct nl_sock *sk)
 	if (sk->s_fd == -1)
 		return -NLE_BAD_SOCK;
 
-	if (fcntl(sk->s_fd, F_SETFL, O_NONBLOCK) < 0)
+	if (fcntl(sk->s_fd, F_SETFL, O_NONBLOCK) < 0) {
+		char buf[64];
+
+		NL_DBG(4, "nl_socket_set_nonblocking(%p): fcntl() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	return 0;
 }
@@ -675,6 +688,7 @@ int nl_socket_modify_err_cb(struct nl_sock *sk, enum nl_cb_kind kind,
 int nl_socket_set_buffer_size(struct nl_sock *sk, int rxbuf, int txbuf)
 {
 	int err;
+	char buf[64];
 
 	if (rxbuf <= 0)
 		rxbuf = 32768;
@@ -687,13 +701,19 @@ int nl_socket_set_buffer_size(struct nl_sock *sk, int rxbuf, int txbuf)
 	
 	err = setsockopt(sk->s_fd, SOL_SOCKET, SO_SNDBUF,
 			 &txbuf, sizeof(txbuf));
-	if (err < 0)
+	if (err < 0) {
+		NL_DBG(4, "nl_socket_set_buffer_size(%p): setsockopt() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	err = setsockopt(sk->s_fd, SOL_SOCKET, SO_RCVBUF,
 			 &rxbuf, sizeof(rxbuf));
-	if (err < 0)
+	if (err < 0) {
+		NL_DBG(4, "nl_socket_set_buffer_size(%p): setsockopt() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	sk->s_flags |= NL_SOCK_BUFSIZE_SET;
 
@@ -746,8 +766,13 @@ int nl_socket_set_passcred(struct nl_sock *sk, int state)
 
 	err = setsockopt(sk->s_fd, SOL_SOCKET, SO_PASSCRED,
 			 &state, sizeof(state));
-	if (err < 0)
+	if (err < 0) {
+		char buf[64];
+
+		NL_DBG(4, "nl_socket_set_passcred(%p): setsockopt() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	if (state)
 		sk->s_flags |= NL_SOCK_PASSCRED;
@@ -773,8 +798,13 @@ int nl_socket_recv_pktinfo(struct nl_sock *sk, int state)
 
 	err = setsockopt(sk->s_fd, SOL_NETLINK, NETLINK_PKTINFO,
 			 &state, sizeof(state));
-	if (err < 0)
+	if (err < 0) {
+		char buf[64];
+
+		NL_DBG(4, "nl_socket_recv_pktinfo(%p): setsockopt() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
 		return -nl_syserr2nlerr(errno);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
nl_syserr2nlerr() reduces a lot of platform errors to NLE_FAILURE --
"Unspecific failure" which makes it somehow hard to track down the real reason
behind a failure.

Logging them with level of 4 makes it a little less painful.