### PR TITLE
Add const-ness to parameters in addr,attr,data where appropriate.

### DIFF
--- a/include/netlink/addr.h
+++ b/include/netlink/addr.h
@@ -22,42 +22,45 @@ struct nl_addr;
 
 /* Creation */
 extern struct nl_addr *	nl_addr_alloc(size_t);
-extern struct nl_addr *	nl_addr_alloc_attr(struct nlattr *, int);
-extern struct nl_addr *	nl_addr_build(int, void *, size_t);
+extern struct nl_addr *	nl_addr_alloc_attr(const struct nlattr *, int);
+extern struct nl_addr *	nl_addr_build(int, const void *, size_t);
 extern int		nl_addr_parse(const char *, int, struct nl_addr **);
-extern struct nl_addr *	nl_addr_clone(struct nl_addr *);
+extern struct nl_addr *	nl_addr_clone(const struct nl_addr *);
 
 /* Usage Management */
 extern struct nl_addr *	nl_addr_get(struct nl_addr *);
 extern void		nl_addr_put(struct nl_addr *);
-extern int		nl_addr_shared(struct nl_addr *);
+extern int		nl_addr_shared(const struct nl_addr *);
 
-extern int		nl_addr_cmp(struct nl_addr *, struct nl_addr *);
-extern int		nl_addr_cmp_prefix(struct nl_addr *, struct nl_addr *);
-extern int		nl_addr_iszero(struct nl_addr *);
-extern int		nl_addr_valid(char *, int);
-extern int      	nl_addr_guess_family(struct nl_addr *);
-extern int		nl_addr_fill_sockaddr(struct nl_addr *,
+extern int		nl_addr_cmp(const struct nl_addr *,
+				    const struct nl_addr *);
+extern int		nl_addr_cmp_prefix(const struct nl_addr *,
+					   const struct nl_addr *);
+extern int		nl_addr_iszero(const struct nl_addr *);
+extern int		nl_addr_valid(const char *, int);
+extern int      	nl_addr_guess_family(const struct nl_addr *);
+extern int		nl_addr_fill_sockaddr(const struct nl_addr *,
 					      struct sockaddr *, socklen_t *);
-extern int		nl_addr_info(struct nl_addr *, struct addrinfo **);
-extern int		nl_addr_resolve(struct nl_addr *, char *, size_t);
+extern int		nl_addr_info(const struct nl_addr *,
+				     struct addrinfo **);
+extern int		nl_addr_resolve(const struct nl_addr *, char *, size_t);
 
 /* Access Functions */
 extern void		nl_addr_set_family(struct nl_addr *, int);
-extern int		nl_addr_get_family(struct nl_addr *);
-extern int		nl_addr_set_binary_addr(struct nl_addr *, void *,
+extern int		nl_addr_get_family(const struct nl_addr *);
+extern int		nl_addr_set_binary_addr(struct nl_addr *, const void *,
 						size_t);
-extern void *		nl_addr_get_binary_addr(struct nl_addr *);
-extern unsigned int	nl_addr_get_len(struct nl_addr *);
+extern void *		nl_addr_get_binary_addr(const struct nl_addr *);
+extern unsigned int	nl_addr_get_len(const struct nl_addr *);
 extern void		nl_addr_set_prefixlen(struct nl_addr *, int);
-extern unsigned int	nl_addr_get_prefixlen(struct nl_addr *);
+extern unsigned int	nl_addr_get_prefixlen(const struct nl_addr *);
 
 /* Address Family Translations */
 extern char *		nl_af2str(int, char *, size_t);
 extern int		nl_str2af(const char *);
 
 /* Translations to Strings */
-extern char *		nl_addr2str(struct nl_addr *, char *, size_t);
+extern char *		nl_addr2str(const struct nl_addr *, char *, size_t);
 
 #ifdef __cplusplus
 }

--- a/include/netlink/attr.h
+++ b/include/netlink/attr.h
@@ -81,12 +81,12 @@ extern int		nla_ok(const struct nlattr *, int);
 extern struct nlattr *	nla_next(const struct nlattr *, int *);
 extern int		nla_parse(struct nlattr **, int, struct nlattr *,
 				  int, struct nla_policy *);
-extern int		nla_validate(struct nlattr *, int, int,
-				     struct nla_policy *);
-extern struct nlattr *	nla_find(struct nlattr *, int, int);
+extern int		nla_validate(const struct nlattr *, int, int,
+				     const struct nla_policy *);
+extern struct nlattr *	nla_find(const struct nlattr *, int, int);
 
 /* Helper Functions */
-extern int		nla_memcpy(void *, struct nlattr *, int);
+extern int		nla_memcpy(void *, const struct nlattr *, int);
 extern size_t		nla_strlcpy(char *, const struct nlattr *, size_t);
 extern int		nla_memcmp(const struct nlattr *, const void *, size_t);
 extern int		nla_strcmp(const struct nlattr *, const char *);
@@ -94,40 +94,42 @@ extern int		nla_strcmp(const struct nlattr *, const char *);
 /* Unspecific attribute */
 extern struct nlattr *	nla_reserve(struct nl_msg *, int, int);
 extern int		nla_put(struct nl_msg *, int, int, const void *);
-extern int		nla_put_data(struct nl_msg *, int, struct nl_data *);
+extern int		nla_put_data(struct nl_msg *, int,
+				     const struct nl_data *);
 extern int		nla_put_addr(struct nl_msg *, int, struct nl_addr *);
 
 /* Integer attribute */
-extern uint8_t		nla_get_u8(struct nlattr *);
+extern uint8_t		nla_get_u8(const struct nlattr *);
 extern int		nla_put_u8(struct nl_msg *, int, uint8_t);
-extern uint16_t		nla_get_u16(struct nlattr *);
+extern uint16_t		nla_get_u16(const struct nlattr *);
 extern int		nla_put_u16(struct nl_msg *, int, uint16_t);
-extern uint32_t		nla_get_u32(struct nlattr *);
+extern uint32_t		nla_get_u32(const struct nlattr *);
 extern int		nla_put_u32(struct nl_msg *, int, uint32_t);
-extern uint64_t		nla_get_u64(struct nlattr *);
+extern uint64_t		nla_get_u64(const struct nlattr *);
 extern int		nla_put_u64(struct nl_msg *, int, uint64_t);
 
 /* String attribute */
-extern char *		nla_get_string(struct nlattr *);
-extern char *		nla_strdup(struct nlattr *);
+extern char *		nla_get_string(const struct nlattr *);
+extern char *		nla_strdup(const struct nlattr *);
 extern int		nla_put_string(struct nl_msg *, int, const char *);
 
 /* Flag attribute */
-extern int		nla_get_flag(struct nlattr *);
+extern int		nla_get_flag(const struct nlattr *);
 extern int		nla_put_flag(struct nl_msg *, int);
 
 /* Msec attribute */
-extern unsigned long	nla_get_msecs(struct nlattr *);
+extern unsigned long	nla_get_msecs(const struct nlattr *);
 extern int		nla_put_msecs(struct nl_msg *, int, unsigned long);
 
 /* Attribute nesting */
-extern int		nla_put_nested(struct nl_msg *, int, struct nl_msg *);
+extern int		nla_put_nested(struct nl_msg *, int,
+				       const struct nl_msg *);
 extern struct nlattr *	nla_nest_start(struct nl_msg *, int);
 extern int		nla_nest_end(struct nl_msg *, struct nlattr *);
-extern void		nla_nest_cancel(struct nl_msg *, struct nlattr *);
+extern void		nla_nest_cancel(struct nl_msg *, const struct nlattr *);
 extern int		nla_parse_nested(struct nlattr **, int, struct nlattr *,
 					 struct nla_policy *);
-extern int		nla_is_nested(struct nlattr *);
+extern int		nla_is_nested(const struct nlattr *);
 
 /**
  * @name Attribute Construction (Exception Based)

--- a/include/netlink/data.h
+++ b/include/netlink/data.h
@@ -21,18 +21,19 @@ extern "C" {
 struct nl_data;
 
 /* General */
-extern struct nl_data *	nl_data_alloc(void *, size_t);
-extern struct nl_data * nl_data_alloc_attr(struct nlattr *);
-extern struct nl_data *	nl_data_clone(struct nl_data *);
-extern int		nl_data_append(struct nl_data *, void *, size_t);
+extern struct nl_data *	nl_data_alloc(const void *, size_t);
+extern struct nl_data * nl_data_alloc_attr(const struct nlattr *);
+extern struct nl_data *	nl_data_clone(const struct nl_data *);
+extern int		nl_data_append(struct nl_data *, const void *, size_t);
 extern void		nl_data_free(struct nl_data *);
 
 /* Access Functions */
-extern void *		nl_data_get(struct nl_data *);
-extern size_t		nl_data_get_size(struct nl_data *);
+extern void *		nl_data_get(const struct nl_data *);
+extern size_t		nl_data_get_size(const struct nl_data *);
 
 /* Misc */
-extern int		nl_data_cmp(struct nl_data *, struct nl_data *);
+extern int		nl_data_cmp(const struct nl_data *,
+				    const struct nl_data *);
 
 #ifdef __cplusplus
 }

--- a/lib/addr.c
+++ b/lib/addr.c
@@ -65,7 +65,7 @@ static inline int do_digit(char *str, uint16_t *addr, uint16_t scale,
 	return 0;
 }
 
-static const char *dnet_ntop(char *addrbuf, size_t addrlen, char *str,
+static const char *dnet_ntop(const char *addrbuf, size_t addrlen, char *str,
 			     size_t len)
 {
 	uint16_t addr = dn_ntohs(*(uint16_t *)addrbuf);
@@ -213,7 +213,7 @@ struct nl_addr *nl_addr_alloc(size_t maxsize)
  *
  * @return Allocated address object or NULL upon failure.
  */
-struct nl_addr *nl_addr_build(int family, void *buf, size_t size)
+struct nl_addr *nl_addr_build(int family, const void *buf, size_t size)
 {
 	struct nl_addr *addr;
 
@@ -252,7 +252,7 @@ struct nl_addr *nl_addr_build(int family, void *buf, size_t size)
  *
  * @return Allocated address object or NULL upon failure.
  */
-struct nl_addr *nl_addr_alloc_attr(struct nlattr *nla, int family)
+struct nl_addr *nl_addr_alloc_attr(const struct nlattr *nla, int family)
 {
 	return nl_addr_build(family, nla_data(nla), nla_len(nla));
 }
@@ -468,7 +468,7 @@ errout:
  *
  * @return Allocated abstract address or NULL upon failure.
  */
-struct nl_addr *nl_addr_clone(struct nl_addr *addr)
+struct nl_addr *nl_addr_clone(const struct nl_addr *addr)
 {
 	struct nl_addr *new;
 
@@ -531,7 +531,7 @@ void nl_addr_put(struct nl_addr *addr)
  *
  * @return Non-zero if the abstract address is shared, otherwise 0.
  */
-int nl_addr_shared(struct nl_addr *addr)
+int nl_addr_shared(const struct nl_addr *addr)
 {
 	return addr->a_refcnt > 1;
 }
@@ -560,7 +560,7 @@ int nl_addr_shared(struct nl_addr *addr)
  * @return Integer less than, equal to or greather than zero if the two
  *         addresses match.
  */
-int nl_addr_cmp(struct nl_addr *a, struct nl_addr *b)
+int nl_addr_cmp(const struct nl_addr *a, const struct nl_addr *b)
 {
 	int d = a->a_family - b->a_family;
 
@@ -591,7 +591,7 @@ int nl_addr_cmp(struct nl_addr *a, struct nl_addr *b)
  * @return Integer less than, equal to or greather than zero if the two
  *         addresses match.
  */
-int nl_addr_cmp_prefix(struct nl_addr *a, struct nl_addr *b)
+int nl_addr_cmp_prefix(const struct nl_addr *a, const struct nl_addr *b)
 {
 	int d = a->a_family - b->a_family;
 
@@ -617,7 +617,7 @@ int nl_addr_cmp_prefix(struct nl_addr *a, struct nl_addr *b)
  *
  * @return 1 if the binary address consists of all zeros, 0 otherwise.
  */
-int nl_addr_iszero(struct nl_addr *addr)
+int nl_addr_iszero(const struct nl_addr *addr)
 {
 	unsigned int i;
 
@@ -636,7 +636,7 @@ int nl_addr_iszero(struct nl_addr *addr)
  * @return 1 if the address is parseable assuming the specified address family,
  *         otherwise 0 is returned.
  */
-int nl_addr_valid(char *addr, int family)
+int nl_addr_valid(const char *addr, int family)
 {
 	int ret;
 	char buf[32];
@@ -670,7 +670,7 @@ int nl_addr_valid(char *addr, int family)
  *
  * @return Numeric address family or AF_UNSPEC
  */
-int nl_addr_guess_family(struct nl_addr *addr)
+int nl_addr_guess_family(const struct nl_addr *addr)
 {
 	switch (addr->a_len) {
 		case 4:
@@ -697,7 +697,7 @@ int nl_addr_guess_family(struct nl_addr *addr)
  *
  * @return 0 on success or a negative error code
  */
-int nl_addr_fill_sockaddr(struct nl_addr *addr, struct sockaddr *sa,
+int nl_addr_fill_sockaddr(const struct nl_addr *addr, struct sockaddr *sa,
 			  socklen_t *salen)
 {
 	switch (addr->a_family) {
@@ -753,7 +753,7 @@ int nl_addr_fill_sockaddr(struct nl_addr *addr, struct sockaddr *sa,
  *
  * @return 0 on success or a negative error code.
  */
-int nl_addr_info(struct nl_addr *addr, struct addrinfo **result)
+int nl_addr_info(const struct nl_addr *addr, struct addrinfo **result)
 {
 	int err;
 	char buf[INET6_ADDRSTRLEN+5];
@@ -797,7 +797,7 @@ int nl_addr_info(struct nl_addr *addr, struct addrinfo **result)
  *
  * @return 0 on success or a negative error code.
  */
-int nl_addr_resolve(struct nl_addr *addr, char *host, size_t hostlen)
+int nl_addr_resolve(const struct nl_addr *addr, char *host, size_t hostlen)
 {
 	int err;
 	struct sockaddr_in6 buf;
@@ -842,7 +842,7 @@ void nl_addr_set_family(struct nl_addr *addr, int family)
  *
  * @return The numeric address family or `AF_UNSPEC`
  */
-int nl_addr_get_family(struct nl_addr *addr)
+int nl_addr_get_family(const struct nl_addr *addr)
 {
 	return addr->a_family;
 }
@@ -867,7 +867,7 @@ int nl_addr_get_family(struct nl_addr *addr)
  *
  * @return 0 on success or a negative error code.
  */
-int nl_addr_set_binary_addr(struct nl_addr *addr, void *buf, size_t len)
+int nl_addr_set_binary_addr(struct nl_addr *addr, const void *buf, size_t len)
 {
 	if (len > addr->a_maxsize)
 		return -NLE_RANGE;
@@ -890,9 +890,9 @@ int nl_addr_set_binary_addr(struct nl_addr *addr, void *buf, size_t len)
  *
  * @return Pointer to binary address of length nl_addr_get_len()
  */
-void *nl_addr_get_binary_addr(struct nl_addr *addr)
+void *nl_addr_get_binary_addr(const struct nl_addr *addr)
 {
-	return addr->a_addr;
+	return (void*)addr->a_addr;
 }
 
 /**
@@ -902,7 +902,7 @@ void *nl_addr_get_binary_addr(struct nl_addr *addr)
  * @see nl_addr_get_binary_addr()
  * @see nl_addr_set_binary_addr()
  */
-unsigned int nl_addr_get_len(struct nl_addr *addr)
+unsigned int nl_addr_get_len(const struct nl_addr *addr)
 {
 	return addr->a_len;
 }
@@ -925,7 +925,7 @@ void nl_addr_set_prefixlen(struct nl_addr *addr, int prefixlen)
  *
  * @see nl_addr_set_prefixlen()
  */
-unsigned int nl_addr_get_prefixlen(struct nl_addr *addr)
+unsigned int nl_addr_get_prefixlen(const struct nl_addr *addr)
 {
 	return addr->a_prefixlen;
 }
@@ -948,7 +948,7 @@ unsigned int nl_addr_get_prefixlen(struct nl_addr *addr)
  *
  * @return Address represented in ASCII stored in destination buffer.
  */
-char *nl_addr2str(struct nl_addr *addr, char *buf, size_t size)
+char *nl_addr2str(const struct nl_addr *addr, char *buf, size_t size)
 {
 	unsigned int i;
 	char tmp[16];

--- a/lib/attr.c
+++ b/lib/attr.c
@@ -185,10 +185,10 @@ static uint16_t nla_attr_minlen[NLA_TYPE_MAX+1] = {
 	[NLA_FLAG]	= 0,
 };
 
-static int validate_nla(struct nlattr *nla, int maxtype,
-			struct nla_policy *policy)
+static int validate_nla(const struct nlattr *nla, int maxtype,
+			const struct nla_policy *policy)
 {
-	struct nla_policy *pt;
+	const struct nla_policy *pt;
 	unsigned int minlen = 0;
 	int type = nla_type(nla);
 
@@ -212,7 +212,7 @@ static int validate_nla(struct nlattr *nla, int maxtype,
 		return -NLE_RANGE;
 
 	if (pt->type == NLA_STRING) {
-		char *data = nla_data(nla);
+		const char *data = nla_data(nla);
 		if (data[nla_len(nla) - 1] != '\0')
 			return -NLE_INVAL;
 	}
@@ -291,10 +291,10 @@ errout:
  *
  * @return 0 on success or a negative error code.
  */
-int nla_validate(struct nlattr *head, int len, int maxtype,
-		 struct nla_policy *policy)
+int nla_validate(const struct nlattr *head, int len, int maxtype,
+		 const struct nla_policy *policy)
 {
-	struct nlattr *nla;
+	const struct nlattr *nla;
 	int rem, err;
 
 	nla_for_each_attr(nla, head, len, rem) {
@@ -320,14 +320,14 @@ errout:
  *
  * @return Pointer to attribute found or NULL.
  */
-struct nlattr *nla_find(struct nlattr *head, int len, int attrtype)
+struct nlattr *nla_find(const struct nlattr *head, int len, int attrtype)
 {
-	struct nlattr *nla;
+	const struct nlattr *nla;
 	int rem;
 
 	nla_for_each_attr(nla, head, len, rem)
 		if (nla_type(nla) == attrtype)
-			return nla;
+			return (struct nlattr*)nla;
 
 	return NULL;
 }
@@ -350,7 +350,7 @@ struct nlattr *nla_find(struct nlattr *head, int len, int attrtype)
  *
  * @return The number of bytes copied to dest.
  */
-int nla_memcpy(void *dest, struct nlattr *src, int count)
+int nla_memcpy(void *dest, const struct nlattr *src, int count)
 {
 	int minlen;
 
@@ -378,7 +378,7 @@ int nla_memcpy(void *dest, struct nlattr *src, int count)
 size_t nla_strlcpy(char *dst, const struct nlattr *nla, size_t dstsize)
 {
 	size_t srclen = nla_len(nla);
-	char *src = nla_data(nla);
+	const char *src = nla_data(nla);
 
 	if (srclen > 0 && src[srclen - 1] == '\0')
 		srclen--;
@@ -524,7 +524,7 @@ int nla_put(struct nl_msg *msg, int attrtype, int datalen, const void *data)
  * @see nla_put
  * @return 0 on success or a negative error code.
  */
-int nla_put_data(struct nl_msg *msg, int attrtype, struct nl_data *data)
+int nla_put_data(struct nl_msg *msg, int attrtype, const struct nl_data *data)
 {
 	return nla_put(msg, attrtype, nl_data_get_size(data),
 		       nl_data_get(data));
@@ -571,9 +571,9 @@ int nla_put_u8(struct nl_msg *msg, int attrtype, uint8_t value)
  *
  * @return Payload as 8 bit integer.
  */
-uint8_t nla_get_u8(struct nlattr *nla)
+uint8_t nla_get_u8(const struct nlattr *nla)
 {
-	return *(uint8_t *) nla_data(nla);
+	return *(const uint8_t *) nla_data(nla);
 }
 
 /**
@@ -596,9 +596,9 @@ int nla_put_u16(struct nl_msg *msg, int attrtype, uint16_t value)
  *
  * @return Payload as 16 bit integer.
  */
-uint16_t nla_get_u16(struct nlattr *nla)
+uint16_t nla_get_u16(const struct nlattr *nla)
 {
-	return *(uint16_t *) nla_data(nla);
+	return *(const uint16_t *) nla_data(nla);
 }
 
 /**
@@ -621,9 +621,9 @@ int nla_put_u32(struct nl_msg *msg, int attrtype, uint32_t value)
  *
  * @return Payload as 32 bit integer.
  */
-uint32_t nla_get_u32(struct nlattr *nla)
+uint32_t nla_get_u32(const struct nlattr *nla)
 {
-	return *(uint32_t *) nla_data(nla);
+	return *(const uint32_t *) nla_data(nla);
 }
 
 /**
@@ -646,7 +646,7 @@ int nla_put_u64(struct nl_msg *msg, int attrtype, uint64_t value)
  *
  * @return Payload as 64 bit integer.
  */
-uint64_t nla_get_u64(struct nlattr *nla)
+uint64_t nla_get_u64(const struct nlattr *nla)
 {
 	uint64_t tmp = 0;
 
@@ -682,12 +682,12 @@ int nla_put_string(struct nl_msg *msg, int attrtype, const char *str)
  *
  * @return Pointer to attribute payload.
  */
-char *nla_get_string(struct nlattr *nla)
+char *nla_get_string(const struct nlattr *nla)
 {
 	return (char *) nla_data(nla);
 }
 
-char *nla_strdup(struct nlattr *nla)
+char *nla_strdup(const struct nlattr *nla)
 {
 	return strdup(nla_get_string(nla));
 }
@@ -717,7 +717,7 @@ int nla_put_flag(struct nl_msg *msg, int attrtype)
  *
  * @return True if flag is set, otherwise false.
  */
-int nla_get_flag(struct nlattr *nla)
+int nla_get_flag(const struct nlattr *nla)
 {
 	return !!nla;
 }
@@ -745,7 +745,7 @@ int nla_put_msecs(struct nl_msg *n, int attrtype, unsigned long msecs)
  *
  * @return the number of milliseconds.
  */
-unsigned long nla_get_msecs(struct nlattr *nla)
+unsigned long nla_get_msecs(const struct nlattr *nla)
 {
 	return nla_get_u64(nla);
 }
@@ -769,7 +769,8 @@ unsigned long nla_get_msecs(struct nlattr *nla)
  * @see nla_put
  * @return 0 on success or a negative error code.
  */
-int nla_put_nested(struct nl_msg *msg, int attrtype, struct nl_msg *nested)
+int nla_put_nested(struct nl_msg *msg, int attrtype,
+		   const struct nl_msg *nested)
 {
 	NL_DBG(2, "msg %p: attr <> %d: adding msg %p as nested attribute\n",
 		msg, attrtype, nested);
@@ -856,7 +857,7 @@ int nla_nest_end(struct nl_msg *msg, struct nlattr *start)
  * by resetting the message to the size before the call to nla_nest_start()
  * and by overwriting any potentially touched message segments with 0.
  */
-void nla_nest_cancel(struct nl_msg *msg, struct nlattr *attr)
+void nla_nest_cancel(struct nl_msg *msg, const struct nlattr *attr)
 {
 	ssize_t len;
 
@@ -894,7 +895,7 @@ int nla_parse_nested(struct nlattr *tb[], int maxtype, struct nlattr *nla,
  *
  * @return True if attribute has NLA_F_NESTED flag set, oterhwise False.
  */
-int nla_is_nested(struct nlattr *attr)
+int nla_is_nested(const struct nlattr *attr)
 {
 	return !!(attr->nla_type & NLA_F_NESTED);
 }

--- a/lib/data.c
+++ b/lib/data.c
@@ -47,7 +47,7 @@
  * 
  * @return Newly allocated data handle or NULL
  */
-struct nl_data *nl_data_alloc(void *buf, size_t size)
+struct nl_data *nl_data_alloc(const void *buf, size_t size)
 {
 	struct nl_data *data;
 
@@ -81,7 +81,7 @@ errout:
  * @see nla_data_alloc
  * @return Newly allocated data handle or NULL
  */
-struct nl_data *nl_data_alloc_attr(struct nlattr *nla)
+struct nl_data *nl_data_alloc_attr(const struct nlattr *nla)
 {
 	return nl_data_alloc(nla_data(nla), nla_len(nla));
 }
@@ -92,7 +92,7 @@ struct nl_data *nl_data_alloc_attr(struct nlattr *nla)
  *
  * @return Cloned object or NULL
  */
-struct nl_data *nl_data_clone(struct nl_data *src)
+struct nl_data *nl_data_clone(const struct nl_data *src)
 {
 	return nl_data_alloc(src->d_data, src->d_size);
 }
@@ -108,7 +108,7 @@ struct nl_data *nl_data_clone(struct nl_data *src)
  * 
  * @return 0 on success or a negative error code
  */
-int nl_data_append(struct nl_data *data, void *buf, size_t size)
+int nl_data_append(struct nl_data *data, const void *buf, size_t size)
 {
 	if (size > 0) {
 		data->d_data = realloc(data->d_data, data->d_size + size);
@@ -150,9 +150,11 @@ void nl_data_free(struct nl_data *data)
  * @arg data		Abstract data object.
  * @return Data buffer or NULL if empty.
  */
-void *nl_data_get(struct nl_data *data)
+void *nl_data_get(const struct nl_data *data)
 {
-	return data->d_size > 0 ? data->d_data : NULL;
+	if (data->d_size > 0)
+		return (void*)data->d_data;
+	return NULL;
 }
 
 /**
@@ -160,7 +162,7 @@ void *nl_data_get(struct nl_data *data)
  * @arg data		Abstract data object.
  * @return Size of data buffer.
  */
-size_t nl_data_get_size(struct nl_data *data)
+size_t nl_data_get_size(const struct nl_data *data)
 {
 	return data->d_size;
 }
@@ -180,10 +182,10 @@ size_t nl_data_get_size(struct nl_data *data)
  *         a is found, respectively, to be less than, to match, or
  *         be greater than b.
  */
-int nl_data_cmp(struct nl_data *a, struct nl_data *b)
+int nl_data_cmp(const struct nl_data *a, const struct nl_data *b)
 {
-	void *a_ = nl_data_get(a);
-	void *b_ = nl_data_get(b);
+	const void *a_ = nl_data_get(a);
+	const void *b_ = nl_data_get(b);
 
 	if (a_ && b_)
 		return memcmp(a_, b_, nl_data_get_size(a));


### PR DESCRIPTION
It seemed strange that functions like nla_get_u8 weren't able to take a 'const struct nlattr*' as the parameter.

It also uses the strchr idiom for returning pointers from within structures
(this idiom already existed in some functions e.g. nla_data).

These changes are only a subset of the places in the library where const-ness could potentially be added.