### PR TITLE
Remove unnecessary include of private linux/if.h

### DIFF
--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -15,7 +15,6 @@
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/addr.h>
-#include <linux/if.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus

--- a/src/nl-link-set.c
+++ b/src/nl-link-set.c
@@ -9,6 +9,7 @@
  * Copyright (c) 2003-2010 Thomas Graf <tgraf@suug.ch>
  */
 
+#include <linux/if.h>
 #include <netlink/cli/utils.h>
 #include <netlink/cli/link.h>
 


### PR DESCRIPTION
Including linux/if.h in netlink/route/link.h causes issues
in cases where libnl is used in conjuntion with other third
party libraries that include net/if.h. Seems to be a long
checkered history of symbol collisions between these two
files. As it turns out, including linux/if.h from within
netlink/route/link.h is actually unecessary. I resurrected
a forgotten path from this thread:

    http://lists.infradead.org/pipermail/libnl/2012-April/000525.html

By removing the include as the patch suggests we can get
around the nuissance of the symbol collisions.