### PR TITLE
Revert "route: remove unnecessary include of private linux/if.h"

### DIFF
--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -15,7 +15,9 @@
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/addr.h>
+#ifndef _LINUX_IF_H
 #include <linux/if.h>
+#endif
 #include <sys/types.h>
 
 #ifdef __cplusplus

--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -15,6 +15,7 @@
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/addr.h>
+#include <linux/if.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus

--- a/src/nl-link-set.c
+++ b/src/nl-link-set.c
@@ -9,7 +9,6 @@
  * Copyright (c) 2003-2010 Thomas Graf <tgraf@suug.ch>
  */
 
-#include <linux/if.h>
 #include <netlink/cli/utils.h>
 #include <netlink/cli/link.h>
 


### PR DESCRIPTION
It's necessary for IFF_* defines as would be used via
rtnl_link_get_flags() checks against for example IFF_UP.

It breaks bmon for example since it never includes linux/if.h, see:
http://autobuild.buildroot.net/results/296/296bcaf4fd1fadcab71881d6d00a8763bfa91a41/build-end.log

This reverts commit 50a76998ac36ace3716d3c979b352fac73cfc80a.