### PR TITLE
NUD_NOARP typo in trans_tbl?

### DIFF
--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -746,7 +746,7 @@ static const struct trans_tbl neigh_states[] = {
 	__ADD(NUD_DELAY, delay),
 	__ADD(NUD_PROBE, probe),
 	__ADD(NUD_FAILED, failed),
-	__ADD(NUD_NOARP, norarp),
+	__ADD(NUD_NOARP, noarp),
 	__ADD(NUD_PERMANENT, permanent),
 };
 


### PR DESCRIPTION
I would expect using rtnl_neigh_str2state("noarp") is translating to NUD_NOARP. Instead of "noarp" you have to use "norarp", which looks pretty much like a typo.

Adding "noarp" additionally might be an option as well... 