### PR TITLE
lib/socket: add network namespace support to sockets

### DIFF
--- a/include/netlink/socket.h
+++ b/include/netlink/socket.h
@@ -64,6 +64,7 @@ extern int              nl_socket_set_fd(struct nl_sock *sk, int protocol, int f
 extern int		nl_socket_set_nonblocking(const struct nl_sock *);
 extern void		nl_socket_enable_msg_peek(struct nl_sock *);
 extern void		nl_socket_disable_msg_peek(struct nl_sock *);
+extern int		nl_socket_set_ns(struct nl_sock *sk, int ns);
 
 #ifdef __cplusplus
 }

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -923,6 +923,33 @@ int nl_socket_recv_pktinfo(struct nl_sock *sk, int state)
 	return 0;
 }
 
+/**
+ * Set the network namespace for the netlink socket to listen on.
+ * @arg sk	Netlink socket.
+ * @arg ns	Network namespace number.
+ *
+ * @return 0 on success or a negative error code.
+ */
+int nl_socket_set_ns(struct nl_sock *sk, int ns)
+{
+	int err;
+
+	if (sk->s_fd == -1)
+		return -NLE_BAD_SOCK;
+
+	err = setsockopt(sk->s_fd, SOL_SOCKET, SO_NSID,
+			 &ns, sizeof(ns));
+	if (err < 0) {
+		char buf[64];
+
+		NL_DBG(4, "nl_socket_switch_ns(%p): setsockopt() failed with %d (%s)\n",
+			sk, errno, strerror_r(errno, buf, sizeof(buf)));
+		return -nl_syserr2nlerr(errno);
+	}
+
+	return 0;
+}
+
 /** @} */
 
 /** @} */

--- a/libnl-3.sym
+++ b/libnl-3.sym
@@ -229,6 +229,7 @@ global:
 	nl_socket_set_peer_groups;
 	nl_socket_set_peer_port;
 	nl_socket_use_seq;
+	nl_socket_set_ns;
 	nl_str2af;
 	nl_str2ether_proto;
 	nl_str2ip_proto;


### PR DESCRIPTION
It is possible to change the network namespace that a netlink socket
is listening in. This patch adds the function 'nl_socket_set_ns()'
to allow this to be configured.