### PR TITLE
lib/nl: add missing header

### DIFF
--- a/lib/nl.c
+++ b/lib/nl.c
@@ -32,6 +32,7 @@
 #include <netlink/handlers.h>
 #include <netlink/msg.h>
 #include <netlink/attr.h>
+#include <linux/socket.h>
 
 /**
  * @defgroup core_types Data Types


### PR DESCRIPTION
CMSG_NXTHDR requires <linux/socket.h>. This fix a build error with the musl C library:

```sh
undefined reference to `__cmsg_nxthdr'
```