### PR TITLE
enabled generation of Doxygen tagfile for libnl API reference

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1562,7 +1562,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = api/libnl.tag
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed
 # in the class index. If set to NO only the inherited external classes

--- a/doc/api/.gitignore
+++ b/doc/api/.gitignore
@@ -4,5 +4,6 @@
 *.map
 *.md5
 *.js
+*.tag
 formula.repository
 jquery.js


### PR DESCRIPTION
This enables other projects which are using Doxygen for documentation
to automatically create hyperlinks to libnl's API reference.

See: http://www.stack.nl/~dimitri/doxygen/manual/external.html