### PR TITLE
Add function to look up neighbour (FDB) by ifindex, mac address and vlan id

### DIFF
--- a/include/netlink/route/neighbour.h
+++ b/include/netlink/route/neighbour.h
@@ -31,6 +31,8 @@ extern int	rtnl_neigh_alloc_cache_flags(struct nl_sock *,
 					     unsigned int);
 extern struct rtnl_neigh *rtnl_neigh_get(struct nl_cache *, int,
 					       struct nl_addr *);
+extern struct rtnl_neigh *rtnl_neigh_get_by_vlan(struct nl_cache *, int,
+						 struct nl_addr *, int);
 
 extern int      rtnl_neigh_parse(struct nlmsghdr *, struct rtnl_neigh **);
 

--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -607,6 +607,32 @@ struct rtnl_neigh * rtnl_neigh_get(struct nl_cache *cache, int ifindex,
 	return NULL;
 }
 
+/**
+ * Look up a neighbour by interface index, link layer address and vlan id
+ * @arg cache		neighbour cache
+ * @arg ifindex 	interface index the neighbour is on
+ * @arg lladdr		link layer address of the neighbour
+ * @arg vlan		vlan id of the neighbour
+ *
+ * @return neighbour handle or NULL if no match was found.
+ */
+struct rtnl_neigh * rtnl_neigh_get_by_vlan(struct nl_cache *cache, int ifindex,
+					   struct nl_addr *lladdr, int vlan)
+{
+	struct rtnl_neigh *neigh;
+
+	nl_list_for_each_entry(neigh, &cache->c_items, ce_list) {
+		if (neigh->n_ifindex == ifindex &&
+		    neigh->n_vlan == vlan &&
+		    neigh->n_lladdr && !nl_addr_cmp(neigh->n_lladdr, lladdr)) {
+			nl_object_get((struct nl_object *) neigh);
+			return neigh;
+		}
+	}
+
+	return NULL;
+}
+
 /** @} */
 
 /**

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -917,5 +917,6 @@ global:
 	rtnl_link_vrf_get_tableid;
 	rtnl_link_vrf_set_tableid;
 	rtnl_neigh_alloc_cache_flags;
+	rtnl_neigh_ll_get;
 } libnl_3_2_27;
 


### PR DESCRIPTION
The` rtnl_neigh_get()` function can not be used to look up a FDB entry in the
neigh cache. This is due to that the function searches among destination
addresses (`NDA_DST`) and not among link layer addresses (`NDA_LLADDR`), which is
used by FDB entries. A FDB entry can also exist in several VLANss, so a VLAN id
parameter is also needed to find a unique entry.
This commit adds a function, `rtnl_neigh_get_by_vlan()` which searches the neigh
cache for a specific neighbour (FDB) entry by interface index, link layer
address and VLAN id.