### PR TITLE
Better flags handling in ->io_compare

### DIFF
--- a/include/netlink-private/route/link/api.h
+++ b/include/netlink-private/route/link/api.h
@@ -62,7 +62,7 @@ struct rtnl_link_info_ops
 
 	/** Called to compare link info parameters between two links. */
 	int	      (*io_compare)(struct rtnl_link *, struct rtnl_link *,
-				    uint32_t attrs, int flags);
+				    int flags);
 
 	struct nl_list_head		io_list;
 };
@@ -159,7 +159,8 @@ extern int			rtnl_link_af_data_compare(struct rtnl_link *a,
 							  struct rtnl_link *b,
 							  int family);
 extern int			rtnl_link_info_data_compare(struct rtnl_link *a,
-							    struct rtnl_link *b);
+							    struct rtnl_link *b,
+							    int flags);
 
 #ifdef __cplusplus
 }

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -1000,7 +1000,7 @@ static uint64_t link_compare(struct nl_object *_a, struct nl_object *_b,
 			goto protinfo_mismatch;
 	}
 
-	diff |= LINK_DIFF(LINKINFO, rtnl_link_info_data_compare(a, b) != 0);
+	diff |= LINK_DIFF(LINKINFO, rtnl_link_info_data_compare(a, b, flags) != 0);
 out:
 	return diff;
 

--- a/lib/route/link/api.c
+++ b/lib/route/link/api.c
@@ -402,7 +402,7 @@ out:
  * @return 0 if link_info data matches or is not present
  * or != 0 if it mismatches.
  */
-int rtnl_link_info_data_compare(struct rtnl_link *a, struct rtnl_link *b)
+int rtnl_link_info_data_compare(struct rtnl_link *a, struct rtnl_link *b, int flags)
 {
 	if (a->l_info_ops != b->l_info_ops)
 		return ~0;
@@ -410,7 +410,7 @@ int rtnl_link_info_data_compare(struct rtnl_link *a, struct rtnl_link *b)
 	if (!a->l_info_ops || !a->l_info_ops->io_compare)
 		return 0;
 
-	return a->l_info_ops->io_compare(a, b, ~0, 0);
+	return a->l_info_ops->io_compare(a, b, flags);
 }
 
 /** @} */

--- a/lib/route/link/vxlan.c
+++ b/lib/route/link/vxlan.c
@@ -446,11 +446,12 @@ nla_put_failure:
 }
 
 static int vxlan_compare(struct rtnl_link *link_a, struct rtnl_link *link_b,
-			uint32_t attrs, int flags)
+			 int flags)
 {
 	struct vxlan_info *a = link_a->l_info;
 	struct vxlan_info *b = link_b->l_info;
 	int diff = 0;
+	uint32_t attrs = ~0;
 
 #define VXLAN_DIFF(ATTR, EXPR) ATTR_DIFF(attrs, VXLAN_ATTR_##ATTR, a, b, EXPR)
 

--- a/lib/route/link/vxlan.c
+++ b/lib/route/link/vxlan.c
@@ -451,7 +451,7 @@ static int vxlan_compare(struct rtnl_link *link_a, struct rtnl_link *link_b,
 	struct vxlan_info *a = link_a->l_info;
 	struct vxlan_info *b = link_b->l_info;
 	int diff = 0;
-	uint32_t attrs = ~0;
+	uint32_t attrs = flags & LOOSE_COMPARISON ? b->ce_mask : ~0;
 
 #define VXLAN_DIFF(ATTR, EXPR) ATTR_DIFF(attrs, VXLAN_ATTR_##ATTR, a, b, EXPR)
 


### PR DESCRIPTION
In order to match links using only attributes that are actually set in the filter object for cache lookups, we need to pass flags (LOOSE_COMPARISON) down to the io_compare op.
Also update vxlan's implementation of this op to handle LOOSE_COMPARISON.