### PR TITLE
Do not include linux/in6.h

### DIFF
--- a/include/linux-private/linux/if_bridge.h
+++ b/include/linux-private/linux/if_bridge.h
@@ -15,7 +15,6 @@
 
 #include <linux/types.h>
 #include <linux/if_ether.h>
-#include <linux/in6.h>
 
 #define SYSFS_BRIDGE_ATTR	"bridge"
 #define SYSFS_BRIDGE_FDB	"brforward"


### PR DESCRIPTION
In file included from ../include/linux-private/linux/if_bridge.h:18:0,
                 from route/link/bridge.c:26:
.../usr/include/linux/in6.h:30:8: error: redefinition of ‘s
truct in6_addr’
 struct in6_addr {