### PR TITLE
route/addr: address attributes based on object

### DIFF
--- a/lib/route/addr.c
+++ b/lib/route/addr.c
@@ -467,12 +467,15 @@ static void addr_dump_stats(struct nl_object *obj, struct nl_dump_params *p)
 static uint32_t addr_id_attrs_get(struct nl_object *obj)
 {
 	struct rtnl_addr *addr = (struct rtnl_addr *)obj;
+	uint32_t rv;
 
 	switch (addr->a_family) {
 	case AF_INET:
-		return (ADDR_ATTR_FAMILY | ADDR_ATTR_IFINDEX |
-		        ADDR_ATTR_LOCAL | ADDR_ATTR_PREFIXLEN |
-		        ADDR_ATTR_PEER);
+		rv = (ADDR_ATTR_FAMILY | ADDR_ATTR_IFINDEX |
+		      ADDR_ATTR_LOCAL | ADDR_ATTR_PREFIXLEN);
+		if (addr->a_peer)
+			rv |= ADDR_ATTR_PEER;
+		return rv;
 	case AF_INET6:
 		return (ADDR_ATTR_FAMILY | ADDR_ATTR_IFINDEX |
 		        ADDR_ATTR_LOCAL);


### PR DESCRIPTION
addr_id_attrs_get returned a fixed set of attributes for AF_INET. This
leads to an invalid cache in case the default cache manager is used.

The error was cause by nl_object_identical, which checkes the ce_mask
of an object against the req_attrs. For route/addr objects the ce_mask
may contain the ADDR_ATTR_PEER, but the addr_id_attrs_get always
includes this attribute. Thus nl_object_identical fails always in case
no peer exists, which is the default for local addresses.

fixes 62f0fdb9