### PR TITLE
compat: enable building on older systems (e.g., RHEL 6)

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -153,6 +153,7 @@ noinst_HEADERS = \
 	linux-private/linux/netlink.h \
 	linux-private/linux/pkt_cls.h \
 	linux-private/linux/sock_diag.h \
+	linux-private/linux/socket.h \
 	linux-private/linux/tc_act/tc_mirred.h \
 	linux-private/linux/tc_act/tc_skbedit.h \
 	linux-private/linux/pkt_sched.h \

--- a/include/linux-private/linux/socket.h
+++ b/include/linux-private/linux/socket.h
@@ -1,0 +1,21 @@
+#ifndef _LINUX_SOCKET_H
+#define _LINUX_SOCKET_H
+
+/*
+ * Desired design of maximum size and alignment (see RFC2553)
+ */
+#define _K_SS_MAXSIZE	128	/* Implementation specific max size */
+#define _K_SS_ALIGNSIZE	(__alignof__ (struct sockaddr *))
+				/* Implementation specific desired alignment */
+
+typedef unsigned short __kernel_sa_family_t;
+
+struct __kernel_sockaddr_storage {
+	__kernel_sa_family_t	ss_family;		/* address family */
+	/* Following field(s) are implementation specific */
+	char		__data[_K_SS_MAXSIZE - sizeof(unsigned short)];
+				/* space to achieve desired size, */
+				/* _SS_MAXSIZE value minus size of ss_family */
+} __attribute__ ((aligned(_K_SS_ALIGNSIZE)));	/* force desired alignment */
+
+#endif /* _LINUX_SOCKET_H */


### PR DESCRIPTION
This type is not present on older systems (e.g., RHEL 6), and libnl3 will not built without it.  So put a check in configure to ensure that this type is available.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>