### PR TITLE
macsec: minor bugfix

### DIFF
--- a/include/linux-private/linux/if_macsec.h
+++ b/include/linux-private/linux/if_macsec.h
@@ -26,6 +26,8 @@
 
 #define MACSEC_MIN_ICV_LEN 8
 #define MACSEC_MAX_ICV_LEN 32
+/* upper limit for ICV length as recommended by IEEE802.1AE-2006 */
+#define MACSEC_STD_ICV_LEN 16
 
 enum macsec_attrs {
 	MACSEC_ATTR_UNSPEC,

--- a/include/netlink-private/utils.h
+++ b/include/netlink-private/utils.h
@@ -12,6 +12,14 @@
 #ifndef NETLINK_UTILS_PRIV_H_
 #define NETLINK_UTILS_PRIV_H_
 
+#include <byteswap.h>
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define ntohll(x) (x)
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+#define ntohll(x) bswap_64((x))
+#endif
+#define htonll(x) ntohll(x)
+
 extern const char *	nl_strerror_l(int err);
 
 #endif

--- a/lib/netfilter/ct.c
+++ b/lib/netfilter/ct.c
@@ -27,20 +27,10 @@
 #include <netlink/attr.h>
 #include <netlink/netfilter/nfnl.h>
 #include <netlink/netfilter/ct.h>
+#include <netlink-private/utils.h>
 
 static struct nl_cache_ops nfnl_ct_ops;
 
-#if __BYTE_ORDER == __BIG_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return x;
-}
-#elif __BYTE_ORDER == __LITTLE_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return bswap_64(x);
-}
-#endif
 
 static struct nla_policy ct_policy[CTA_MAX+1] = {
 	[CTA_TUPLE_ORIG]	= { .type = NLA_NESTED },

--- a/lib/netfilter/log_msg.c
+++ b/lib/netfilter/log_msg.c
@@ -26,19 +26,7 @@
 #include <netlink/attr.h>
 #include <netlink/netfilter/nfnl.h>
 #include <netlink/netfilter/log_msg.h>
-#include <byteswap.h>
-
-#if __BYTE_ORDER == __BIG_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return x;
-}
-#elif __BYTE_ORDER == __LITTLE_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return bswap_64(x);
-}
-#endif
+#include <netlink-private/utils.h>
 
 static struct nla_policy log_msg_policy[NFULA_MAX+1] = {
 	[NFULA_PACKET_HDR]		= {

--- a/lib/netfilter/queue_msg.c
+++ b/lib/netfilter/queue_msg.c
@@ -24,21 +24,9 @@
 #include <netlink/attr.h>
 #include <netlink/netfilter/nfnl.h>
 #include <netlink/netfilter/queue_msg.h>
-#include <byteswap.h>
+#include <netlink-private/utils.h>
 
 static struct nl_cache_ops nfnl_queue_msg_ops;
-
-#if __BYTE_ORDER == __BIG_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return x;
-}
-#elif __BYTE_ORDER == __LITTLE_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return bswap_64(x);
-}
-#endif
 
 static struct nla_policy queue_policy[NFQA_MAX+1] = {
 	[NFQA_PACKET_HDR]		= {

--- a/lib/route/link/macsec.c
+++ b/lib/route/link/macsec.c
@@ -16,23 +16,9 @@
 #include <netlink/object.h>
 #include <netlink/route/rtnl.h>
 #include <netlink-private/route/link/api.h>
+#include <netlink-private/utils.h>
 
 #include <linux/if_macsec.h>
-
-#include <byteswap.h>
-
-#if __BYTE_ORDER == __BIG_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return x;
-}
-#elif __BYTE_ORDER == __LITTLE_ENDIAN
-static uint64_t ntohll(uint64_t x)
-{
-	return bswap_64(x);
-}
-#endif
-#define htonll(x) ntohll(x)
 
 #define MACSEC_ATTR_SCI			(1 << 0)
 #define MACSEC_ATTR_ICV_LEN		(1 << 1)

--- a/lib/route/link/macsec.c
+++ b/lib/route/link/macsec.c
@@ -509,7 +509,7 @@ int rtnl_link_macsec_set_icv_len(struct rtnl_link *link, uint16_t icv_len)
 
 	IS_MACSEC_LINK_ASSERT(link);
 
-	if (icv_len > MACSEC_MAX_ICV_LEN)
+	if (icv_len > MACSEC_STD_ICV_LEN)
 		return -NLE_INVAL;
 
 	info->icv_len = icv_len;


### PR DESCRIPTION
this  pull request contains two small fixes for macsec:
* limit the maximum ICV length (16 octets instead of 32)
* fix endianness of 'sci' parameter 

In addition, multiple implementations hof htonll() and ntohll() have been replaced with a single #define in include/netlink-private/utils.h