### PR TITLE
macvlan: add support for "source" mode

### DIFF
--- a/include/netlink/route/link/macvlan.h
+++ b/include/netlink/route/link/macvlan.h
@@ -29,6 +29,9 @@ extern int		rtnl_link_macvlan_str2mode(const char *);
 extern char *		rtnl_link_macvlan_flags2str(int, char *, size_t);
 extern int		rtnl_link_macvlan_str2flags(const char *);
 
+extern char *		rtnl_link_macvlan_macmode2str(int, char *, size_t);
+extern int		rtnl_link_macvlan_str2macmode(const char *);
+
 extern int		rtnl_link_macvlan_set_mode(struct rtnl_link *,
 			                           uint32_t);
 extern uint32_t		rtnl_link_macvlan_get_mode(struct rtnl_link *);
@@ -38,6 +41,21 @@ extern int		rtnl_link_macvlan_set_flags(struct rtnl_link *,
 extern int		rtnl_link_macvlan_unset_flags(struct rtnl_link *,
 						   uint16_t);
 extern uint16_t		rtnl_link_macvlan_get_flags(struct rtnl_link *);
+
+extern int		rtnl_link_macvlan_set_macmode(struct rtnl_link *,
+						      uint32_t);
+extern int		rtnl_link_macvlan_get_macmode(struct rtnl_link *link,
+						      uint32_t *out_macmode);
+
+extern int		rtnl_link_macvlan_count_macaddr(struct rtnl_link *link,
+							uint32_t *out_count);
+extern int		rtnl_link_macvlan_get_macaddr(struct rtnl_link *link,
+						      unsigned int idx,
+						      const struct nl_addr **addr);
+extern int		rtnl_link_macvlan_add_macaddr(struct rtnl_link *link,
+						      struct nl_addr *addr);
+extern int		rtnl_link_macvlan_del_macaddr(struct rtnl_link *link,
+						      struct nl_addr *addr);
 
 #ifdef __cplusplus
 }

--- a/lib/route/link/macvlan.c
+++ b/lib/route/link/macvlan.c
@@ -38,12 +38,17 @@
 /** @cond SKIP */
 #define MACVLAN_HAS_MODE	(1<<0)
 #define MACVLAN_HAS_FLAGS	(1<<1)
+#define MACVLAN_HAS_MACCOUNT	(1<<2)
+#define MACVLAN_HAS_MACDATA	(1<<3)
 
 struct macvlan_info
 {
 	uint32_t		mvi_mode;
 	uint16_t		mvi_flags; // there currently is only one flag and kernel has no flags_mask yet
 	uint32_t		mvi_mask;
+	uint32_t		mvi_maccount;
+	uint32_t		mvi_macmode;
+	struct nl_addr		**mvi_macaddr;
 };
 
 /** @endcond */
@@ -51,20 +56,26 @@ struct macvlan_info
 static struct nla_policy macvlan_policy[IFLA_MACVLAN_MAX+1] = {
 	[IFLA_MACVLAN_MODE]	= { .type = NLA_U32 },
 	[IFLA_MACVLAN_FLAGS]	= { .type = NLA_U16 },
+	[IFLA_MACVLAN_MACADDR_MODE]	= { .type = NLA_U32 },
+	[IFLA_MACVLAN_MACADDR]		= { .type = NLA_UNSPEC },
+	[IFLA_MACVLAN_MACADDR_DATA]	= { .type = NLA_NESTED },
+	[IFLA_MACVLAN_MACADDR_COUNT]	= { .type = NLA_U32 },
 };
 
 static int macvlan_alloc(struct rtnl_link *link)
 {
 	struct macvlan_info *mvi;
 
-	if (link->l_info)
-		memset(link->l_info, 0, sizeof(*mvi));
-	else {
+	if (link->l_info) {
+		mvi = link->l_info;
+		memset(mvi, 0, sizeof(*mvi));
+	} else {
 		if ((mvi = calloc(1, sizeof(*mvi))) == NULL)
 			return -NLE_NOMEM;
 
 		link->l_info = mvi;
 	}
+	mvi->mvi_macmode = MACVLAN_MACADDR_SET;
 
 	return 0;
 }
@@ -74,6 +85,9 @@ static int macvlan_parse(struct rtnl_link *link, struct nlattr *data,
 {
 	struct nlattr *tb[IFLA_MACVLAN_MAX+1];
 	struct macvlan_info *mvi;
+	struct nlattr *nla;
+	int i;
+	int len;
 	int err;
 
 	NL_DBG(3, "Parsing %s link info", link->l_info_ops->io_name);
@@ -96,6 +110,33 @@ static int macvlan_parse(struct rtnl_link *link, struct nlattr *data,
 		mvi->mvi_mask |= MACVLAN_HAS_FLAGS;
 	}
 
+	if (tb[IFLA_MACVLAN_MACADDR_COUNT]) {
+		mvi->mvi_maccount = nla_get_u32(tb[IFLA_MACVLAN_MACADDR_COUNT]);
+		mvi->mvi_mask |= MACVLAN_HAS_MACCOUNT;
+	}
+
+	if (tb[IFLA_MACVLAN_MACADDR_DATA] &&
+	    (mvi->mvi_mask & MACVLAN_HAS_MACCOUNT) &&
+	    mvi->mvi_maccount > 0) {
+		nla = nla_data(tb[IFLA_MACVLAN_MACADDR_DATA]);
+		len = nla_len(tb[IFLA_MACVLAN_MACADDR_DATA]);
+
+		mvi->mvi_macaddr = calloc(mvi->mvi_maccount,
+					  sizeof(*(mvi->mvi_macaddr)));
+		mvi->mvi_mask |= MACVLAN_HAS_MACDATA;
+		i = 0;
+
+		for (; nla_ok(nla, len); nla = nla_next(nla, &len)) {
+			if (i >= mvi->mvi_maccount)
+				break;
+			if (nla_type(nla) != IFLA_MACVLAN_MACADDR ||
+			    nla_len(nla) < ETH_ALEN)
+				continue;
+			mvi->mvi_macaddr[i] = nl_addr_alloc_attr(nla, AF_LLC);
+			i++;
+		}
+	}
+
 	err = 0;
 errout:
 	return err;
@@ -103,13 +144,25 @@ errout:
 
 static void macvlan_free(struct rtnl_link *link)
 {
-	free(link->l_info);
+	struct macvlan_info *mvi;
+	int i;
+
+	mvi = link->l_info;
+
+	if (mvi->mvi_mask & MACVLAN_HAS_MACDATA) {
+		for (i = 0; i < mvi->mvi_maccount; i++)
+			nl_addr_put(mvi->mvi_macaddr[i]);
+	}
+	free(mvi->mvi_macaddr);
+	free(mvi);
+
 	link->l_info = NULL;
 }
 
 static void macvlan_dump(struct rtnl_link *link, struct nl_dump_params *p)
 {
 	char buf[64];
+	int i;
 	struct macvlan_info *mvi = link->l_info;
 
 	if (mvi->mvi_mask & MACVLAN_HAS_MODE) {
@@ -121,12 +174,23 @@ static void macvlan_dump(struct rtnl_link *link, struct nl_dump_params *p)
 		rtnl_link_macvlan_flags2str(mvi->mvi_flags, buf, sizeof(buf));
 		nl_dump(p, "%s-flags %s", link->l_info_ops->io_name, buf);
 	}
+
+	if (mvi->mvi_mask & MACVLAN_HAS_MACCOUNT)
+		nl_dump(p, "macvlan-count %d", mvi->mvi_maccount);
+
+	if (mvi->mvi_mask & MACVLAN_HAS_MACDATA) {
+		for (i = 0; i < mvi->mvi_maccount; i++)
+			nl_dump(p, "macvlan-sourcemac %s",
+				nl_addr2str(mvi->mvi_macaddr[i], buf,
+					    sizeof(buf)));
+	}
 }
 
 static int macvlan_clone(struct rtnl_link *dst, struct rtnl_link *src)
 {
 	struct macvlan_info *vdst, *vsrc = src->l_info;
 	int err;
+	int i;
 
 	dst->l_info = NULL;
 	if ((err = rtnl_link_set_type(dst, "macvlan")) < 0)
@@ -138,16 +202,28 @@ static int macvlan_clone(struct rtnl_link *dst, struct rtnl_link *src)
 
 	memcpy(vdst, vsrc, sizeof(struct macvlan_info));
 
+	if (vsrc->mvi_mask & MACVLAN_HAS_MACDATA) {
+		vdst->mvi_macaddr = calloc(vdst->mvi_maccount,
+					   sizeof(*(vdst->mvi_macaddr)));
+		for (i = 0; i < vdst->mvi_maccount; i++)
+			vdst->mvi_macaddr[i] = nl_addr_clone(vsrc->mvi_macaddr[i]);
+	}
+
+	vdst->mvi_macmode = vsrc->mvi_macmode;
+
 	return 0;
 }
 
 static int macvlan_put_attrs(struct nl_msg *msg, struct rtnl_link *link)
 {
 	struct macvlan_info *mvi = link->l_info;
-	struct nlattr *data;
+	struct nlattr *data, *datamac = NULL;
+	int i, ret;
 
 	if (!(data = nla_nest_start(msg, IFLA_INFO_DATA)))
 		return -NLE_MSGSIZE;
+
+	ret = -NLE_NOMEM;
 
 	if (mvi->mvi_mask & MACVLAN_HAS_MODE)
 		NLA_PUT_U32(msg, IFLA_MACVLAN_MODE, mvi->mvi_mode);
@@ -155,11 +231,27 @@ static int macvlan_put_attrs(struct nl_msg *msg, struct rtnl_link *link)
 	if (mvi->mvi_mask & MACVLAN_HAS_FLAGS)
 		NLA_PUT_U16(msg, IFLA_MACVLAN_FLAGS, mvi->mvi_flags);
 
-	nla_nest_end(msg, data);
+	if (mvi->mvi_mask & MACVLAN_HAS_MACDATA) {
+		NLA_PUT_U32(msg, IFLA_MACVLAN_MACADDR_MODE, mvi->mvi_macmode);
+		datamac = nla_nest_start(msg, IFLA_MACVLAN_MACADDR_DATA);
+		if (!datamac)
+			goto nla_put_failure;
+
+		for (i = 0; i < mvi->mvi_maccount; i++) {
+			NLA_PUT_ADDR(msg, IFLA_MACVLAN_MACADDR,
+				     mvi->mvi_macaddr[i]);
+		}
+	}
+
+	ret = 0;
 
 nla_put_failure:
+	if (datamac)
+		nla_nest_end(msg, datamac);
 
-	return 0;
+	nla_nest_end(msg, data);
+
+	return ret;
 }
 
 static struct rtnl_link_info_ops macvlan_info_ops = {
@@ -249,11 +341,23 @@ int rtnl_link_is_macvlan(struct rtnl_link *link)
 int rtnl_link_macvlan_set_mode(struct rtnl_link *link, uint32_t mode)
 {
 	struct macvlan_info *mvi = link->l_info;
+	int i;
 
 	IS_MACVLAN_LINK_ASSERT(link);
 
 	mvi->mvi_mode = mode;
 	mvi->mvi_mask |= MACVLAN_HAS_MODE;
+
+	if (mode != MACVLAN_MODE_SOURCE) {
+		if (mvi->mvi_mask & MACVLAN_HAS_MACDATA) {
+			for (i = 0; i < mvi->mvi_maccount; i++)
+				nl_addr_put(mvi->mvi_macaddr[i]);
+		}
+		free(mvi->mvi_macaddr);
+		mvi->mvi_macaddr = NULL;
+		mvi->mvi_mask &= ~MACVLAN_HAS_MACDATA;
+		mvi->mvi_mask &= ~MACVLAN_HAS_MACCOUNT;
+	}
 
 	return 0;
 }
@@ -274,6 +378,54 @@ uint32_t rtnl_link_macvlan_get_mode(struct rtnl_link *link)
 		return mvi->mvi_mode;
 	else
 		return 0;
+}
+
+/**
+ * Set MACVLAN MACMODE
+ * @arg link		Link object
+ * @arg mode		MACVLAN mac list modification mode
+ *
+ * Only for macvlan SOURCE mode.
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_macvlan_set_macmode(struct rtnl_link *link, uint32_t macmode)
+{
+	struct macvlan_info *mvi = link->l_info;
+
+	IS_MACVLAN_LINK_ASSERT(link);
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MODE) ||
+	    (mvi->mvi_mode != MACVLAN_MODE_SOURCE))
+		return -NLE_INVAL;
+
+	mvi->mvi_macmode = macmode;
+
+	return 0;
+}
+
+/**
+ * Get MACVLAN MACMODE
+ * @arg link		Link object
+ * @arg out_macmode	mac list modification mode
+ *
+ * Only for SOURCE mode.
+ *
+ * @return 0 on success or a negative error code.
+ */
+int rtnl_link_macvlan_get_macmode(struct rtnl_link *link, uint32_t *out_macmode)
+{
+	struct macvlan_info *mvi = link->l_info;
+
+	IS_MACVLAN_LINK_ASSERT(link);
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MODE) ||
+	    (mvi->mvi_mode != MACVLAN_MODE_SOURCE))
+		return -NLE_INVAL;
+
+	*out_macmode = mvi->mvi_macmode;
+
+	return 0;
 }
 
 /**
@@ -330,6 +482,153 @@ uint16_t rtnl_link_macvlan_get_flags(struct rtnl_link *link)
 	IS_MACVLAN_LINK_ASSERT(link);
 
 	return mvi->mvi_flags;
+}
+
+/**
+ * Get number of MAC-Addr for MACVLAN device in source mode
+ * @arg link		Link object
+ * @arg out_count	number of mac addresses
+ *
+ * @return 0 on success or a negative error code.
+ */
+int rtnl_link_macvlan_count_macaddr(struct rtnl_link *link, uint32_t *out_count)
+{
+	struct macvlan_info *mvi = link->l_info;
+
+	IS_MACVLAN_LINK_ASSERT(link);
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MODE) ||
+	    (mvi->mvi_mode != MACVLAN_MODE_SOURCE))
+		return -NLE_INVAL;
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MACCOUNT))
+		return -NLE_INVAL;
+
+	*out_count = mvi->mvi_maccount;
+
+	return 0;
+}
+
+/**
+ * Get configured remote MAC-Addr from MACVLAN device in source mode
+ * @arg link		Link object
+ * @arg out_addr        address object
+ *
+ * The returned nl_addr struct needs NOT to be released using nl_addr_put.
+ * It is only valid until the address is not removed from this link object
+ * or its mode is changed to non-source.
+ *
+ * @return 0 on success or negative error code
+ */
+int rtnl_link_macvlan_get_macaddr(struct rtnl_link *link, unsigned int idx,
+				  const struct nl_addr **out_addr)
+{
+	struct macvlan_info *mvi = link->l_info;
+
+	IS_MACVLAN_LINK_ASSERT(link);
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MODE) ||
+	    (mvi->mvi_mode != MACVLAN_MODE_SOURCE))
+		return -NLE_INVAL;
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MACCOUNT) ||
+	    !(mvi->mvi_mask & MACVLAN_HAS_MACDATA))
+		return -NLE_INVAL;
+
+	if (idx >= mvi->mvi_maccount)
+		*out_addr = NULL;
+	else
+		*out_addr = mvi->mvi_macaddr[idx];
+
+	return 0;
+}
+
+/**
+ * Add MAC-Addr to MACVLAN device in source mode
+ * @arg link		Link object
+ * @arg addr		MAC-Addr
+ *
+ * addr is not release but cloned by this method.
+ *
+ * @return 0 on success or a negative error code.
+ */
+int rtnl_link_macvlan_add_macaddr(struct rtnl_link *link, struct nl_addr *addr)
+{
+	struct macvlan_info *mvi = link->l_info;
+	struct nl_addr **mvi_macaddr;
+	size_t newsize;
+
+	IS_MACVLAN_LINK_ASSERT(link);
+
+	if (nl_addr_get_family(addr) != AF_LLC)
+		return -NLE_INVAL;
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MODE) ||
+	    (mvi->mvi_mode != MACVLAN_MODE_SOURCE))
+		return -NLE_INVAL;
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MACCOUNT) ||
+	    !(mvi->mvi_mask & MACVLAN_HAS_MACDATA))
+		return -NLE_INVAL;
+
+	newsize = (mvi->mvi_maccount + 1) * sizeof(*(mvi->mvi_macaddr));
+	mvi_macaddr = realloc(mvi->mvi_macaddr, newsize);
+	if (!mvi_macaddr)
+		return -NLE_NOMEM;
+
+	mvi->mvi_macaddr = mvi_macaddr;
+	mvi->mvi_macaddr[mvi->mvi_maccount] = nl_addr_clone(addr);
+	mvi->mvi_maccount++;
+
+	mvi->mvi_mask |= MACVLAN_HAS_MACCOUNT;
+	mvi->mvi_mask |= MACVLAN_HAS_MACDATA;
+
+	return 0;
+}
+
+/**
+ * Remove MAC-Addr from MACVLAN device in source mode
+ * @arg link		Link object
+ * @arg addr		MAC-Addr
+ *
+ * addr is not release by this method.
+ *
+ * @return 0 on success or a negative error code.
+ */
+int rtnl_link_macvlan_del_macaddr(struct rtnl_link *link, struct nl_addr *addr)
+{
+	struct macvlan_info *mvi = link->l_info;
+	int found, i;
+
+	IS_MACVLAN_LINK_ASSERT(link);
+
+	if (nl_addr_get_family(addr) != AF_LLC)
+		return -NLE_INVAL;
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MODE) ||
+	    (mvi->mvi_mode != MACVLAN_MODE_SOURCE))
+		return -NLE_INVAL;
+
+	if (!(mvi->mvi_mask & MACVLAN_HAS_MACCOUNT) ||
+	    !(mvi->mvi_mask & MACVLAN_HAS_MACDATA))
+		return -NLE_INVAL;
+
+	found = 0; i = 0;
+	while (i + found < mvi->mvi_maccount) {
+		mvi->mvi_macaddr[i] = mvi->mvi_macaddr[i + found];
+		if (found > 0)
+			mvi->mvi_macaddr[i + found] = NULL;
+		if (nl_addr_cmp(addr, mvi->mvi_macaddr[i]) == 0) {
+			nl_addr_put(mvi->mvi_macaddr[i]);
+			mvi->mvi_macaddr[i] = NULL;
+			found++;
+		} else
+			i++;
+	}
+
+	mvi->mvi_maccount -= found;
+
+	return 0;
 }
 
 /** @} */
@@ -477,6 +776,14 @@ static const struct trans_tbl macvlan_modes[] = {
 	__ADD(MACVLAN_MODE_VEPA, vepa),
 	__ADD(MACVLAN_MODE_BRIDGE, bridge),
 	__ADD(MACVLAN_MODE_PASSTHRU, passthru),
+	__ADD(MACVLAN_MODE_SOURCE, source),
+};
+
+static const struct trans_tbl macvlan_macmodes[] = {
+	__ADD(MACVLAN_MACADDR_ADD, "add"),
+	__ADD(MACVLAN_MACADDR_DEL, "del"),
+	__ADD(MACVLAN_MACADDR_SET, "set"),
+	__ADD(MACVLAN_MACADDR_FLUSH, "flush"),
 };
 
 /**
@@ -519,6 +826,17 @@ char *rtnl_link_macvlan_mode2str(int mode, char *buf, size_t len)
 int rtnl_link_macvlan_str2mode(const char *name)
 {
 	return __str2type(name, macvlan_modes, ARRAY_SIZE(macvlan_modes));
+}
+
+char *rtnl_link_macvlan_macmode2str(int mode, char *buf, size_t len)
+{
+	return __type2str(mode, buf, len, macvlan_modes,
+			  ARRAY_SIZE(macvlan_macmodes));
+}
+
+int rtnl_link_macvlan_str2macmode(const char *name)
+{
+	return __str2type(name, macvlan_modes, ARRAY_SIZE(macvlan_macmodes));
 }
 
 char *rtnl_link_macvtap_mode2str(int mode, char *buf, size_t len)

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -956,5 +956,13 @@ global:
 	rtnl_link_bridge_set_hwmode;
 	rtnl_link_bridge_hwmode2str;
 	rtnl_link_bridge_str2hwmode;
+	rtnl_link_macvlan_add_macaddr;
+	rtnl_link_macvlan_count_macaddr;
+	rtnl_link_macvlan_del_macaddr;
+	rtnl_link_macvlan_get_macaddr;
+	rtnl_link_macvlan_get_macmode;
+	rtnl_link_macvlan_macmode2str;
+	rtnl_link_macvlan_set_macmode;
+	rtnl_link_macvlan_str2macmode;
 } libnl_3_2_28;
 


### PR DESCRIPTION
This adds libnl support for new "source" mode.

Signed-off-by: Michael Braun <michael-dev@fami-braun.de>