### PR TITLE
xfrm: fix xfrm security context management

### DIFF
--- a/include/netlink-private/types.h
+++ b/include/netlink-private/types.h
@@ -1155,6 +1155,7 @@ struct xfrmnl_encap_tmpl {
 	struct nl_addr* encap_oa;
 };
 
+/* kernel space structure, don't use to retrieve/pass sec ctx attribute! */
 struct xfrmnl_sec_ctx {
 	uint8_t         ctx_doi;
 	uint8_t         ctx_alg;
@@ -1186,7 +1187,7 @@ struct xfrmnl_sa {
 	uint32_t                        tfcpad;
 	struct nl_addr*                 coaddr;
 	struct xfrmnl_mark              mark;
-	struct xfrmnl_sec_ctx*          sec_ctx;
+	struct xfrmnl_user_sec_ctx*     sec_ctx;
 	uint32_t                        replay_maxage;
 	uint32_t                        replay_maxdiff;
 	struct xfrmnl_replay_state      replay_state;

--- a/include/netlink/utils.h
+++ b/include/netlink/utils.h
@@ -231,6 +231,13 @@ enum {
 	NL_CAPABILITY_NL_ADDR_FILL_SOCKADDR = 21,
 #define NL_CAPABILITY_NL_ADDR_FILL_SOCKADDR NL_CAPABILITY_NL_ADDR_FILL_SOCKADDR
 
+	/**
+	 * Support omitting @ctx_str argument to xfrmnl_sa_get_sec_ctx() to check
+	 * for required buffer size for context string.
+	 */
+	NL_CAPABILITY_XFRM_SEC_CTX_LEN = 22,
+#define NL_CAPABILITY_XFRM_SEC_CTX_LEN NL_CAPABILITY_XFRM_SEC_CTX_LEN
+
 	__NL_CAPABILITY_MAX,
 	NL_CAPABILITY_MAX = (__NL_CAPABILITY_MAX - 1),
 #define NL_CAPABILITY_MAX NL_CAPABILITY_MAX

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -1190,7 +1190,7 @@ int nl_has_capability (int capability)
 			NL_CAPABILITY_VERSION_3_2_28,
 			NL_CAPABILITY_RTNL_ADDR_PEER_ID_FIX,
 			NL_CAPABILITY_NL_ADDR_FILL_SOCKADDR,
-			0,
+			NL_CAPABILITY_XFRM_SEC_CTX_LEN,
 			0,
 			0),
 		/* IMPORTANT: these capability numbers are intended to be universal and stable

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -1635,6 +1635,8 @@ int xfrmnl_sa_set_flags (struct xfrmnl_sa* sa, unsigned int flags)
  *
  * Warning: you must ensure that @key is large enough. If you don't know the key_len before-hand,
  * call xfrmnl_sa_get_aead_params() without @key argument to query only the required buffer size.
+ * This modified API is available in all versions of libnl3 that support the capability
+ * @def NL_CAPABILITY_XFRM_SA_KEY_SIZE (@see nl_has_capability for further information).
  *
  * @return 0 on success or a negative error code.
  */
@@ -1690,6 +1692,8 @@ int xfrmnl_sa_set_aead_params (struct xfrmnl_sa* sa, const char* alg_name, unsig
  *
  * Warning: you must ensure that @key is large enough. If you don't know the key_len before-hand,
  * call xfrmnl_sa_get_auth_params() without @key argument to query only the required buffer size.
+ * This modified API is available in all versions of libnl3 that support the capability
+ * @def NL_CAPABILITY_XFRM_SA_KEY_SIZE (@see nl_has_capability for further information).
  *
  * @return 0 on success or a negative error code.
  */
@@ -1744,6 +1748,8 @@ int xfrmnl_sa_set_auth_params (struct xfrmnl_sa* sa, const char* alg_name, unsig
  *
  * Warning: you must ensure that @key is large enough. If you don't know the key_len before-hand,
  * call xfrmnl_sa_get_crypto_params() without @key argument to query only the required buffer size.
+ * This modified API is available in all versions of libnl3 that support the capability
+ * @def NL_CAPABILITY_XFRM_SA_KEY_SIZE (@see nl_has_capability for further information).
  *
  * @return 0 on success or a negative error code.
  */
@@ -1795,6 +1801,8 @@ int xfrmnl_sa_set_crypto_params (struct xfrmnl_sa* sa, const char* alg_name, uns
  *
  * Warning: you must ensure that @key is large enough. If you don't know the key_len before-hand,
  * call xfrmnl_sa_get_comp_params() without @key argument to query only the required buffer size.
+ * This modified API is available in all versions of libnl3 that support the capability
+ * @def NL_CAPABILITY_XFRM_SA_KEY_SIZE (@see nl_has_capability for further information).
  *
  * @return 0 on success or a negative error code.
  */


### PR DESCRIPTION
The data structure of choice when adding/processing a security context
for xfrm is struct xfrm(nl)_user_sec_ctx. The previous code did however
use the (also exported) struct xfrm(nl)_sec_ctx. While sizeof(struct
xfrm(nl)_*sec_ctx) yields the same result, the interpretation of one of
the data structures as the other one messes up the contents.
With this fix, the wrong data structure has been replaced with the
correct one. Also -- since the size of the context string is not known
-- one can now call xfrmnl_sa_get_sec_ctx with ctx_str being NULL, thus
retrieving the length of the context string.
A new capability has been introduced, to test whether libnl3 supports
the modified semantics of this function.

Signed-off-by: Thomas Egerer thomas.egerer@secunet.com
