### PR TITLE
Add MULTIPATH to route attribute list

### DIFF
--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -1310,7 +1310,7 @@ struct nl_object_ops route_obj_ops = {
 	.oo_attrs2str		= route_attrs2str,
 	.oo_id_attrs		= (ROUTE_ATTR_FAMILY | ROUTE_ATTR_TOS |
 				   ROUTE_ATTR_TABLE | ROUTE_ATTR_DST |
-				   ROUTE_ATTR_PRIO),
+				   ROUTE_ATTR_PRIO | ROUTE_ATTR_MULTIPATH),
 };
 /** @endcond */
 


### PR DESCRIPTION
When comparing route objects, we need to include multipath attribute so routes which have the same prefixes via different nextHop interfaces can
be differentiated. Example: Multicast routes: ff00::/8 via eth0 and
ff00::/8 via eht1