### PR TITLE
lib/route: keep link stats minlen compatible with kernel < 4.6

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -313,6 +313,11 @@ static int link_clone(struct nl_object *_dst, struct nl_object *_src)
 	return 0;
 }
 
+/* struct rtnl_link_stats doesn't have rx_nohandler in kernel versions < 4.6 */
+#define IFLA_STATS_MINLEN (sizeof(struct rtnl_link_stats) - sizeof(__u32))
+/* struct rtnl_link_stats64 doesn't have rx_nohandler in kernel versions < 4.6 */
+#define IFLA_STATS64_MINLEN (sizeof(struct rtnl_link_stats64) - sizeof(__u64))
+
 struct nla_policy rtln_link_policy[IFLA_MAX+1] = {
 	[IFLA_IFNAME]		= { .type = NLA_STRING,
 				    .maxlen = IFNAMSIZ },
@@ -326,8 +331,8 @@ struct nla_policy rtln_link_policy[IFLA_MAX+1] = {
 	[IFLA_LINKINFO]		= { .type = NLA_NESTED },
 	[IFLA_QDISC]		= { .type = NLA_STRING,
 				    .maxlen = IFQDISCSIZ },
-	[IFLA_STATS]		= { .minlen = sizeof(struct rtnl_link_stats) },
-	[IFLA_STATS64]		= { .minlen = sizeof(struct rtnl_link_stats64)},
+	[IFLA_STATS]		= { .minlen = IFLA_STATS_MINLEN },
+	[IFLA_STATS64]		= { .minlen = IFLA_STATS64_MINLEN },
 	[IFLA_MAP]		= { .minlen = sizeof(struct rtnl_link_ifmap) },
 	[IFLA_IFALIAS]		= { .type = NLA_STRING, .maxlen = IFALIASZ },
 	[IFLA_NUM_VF]		= { .type = NLA_U32 },


### PR DESCRIPTION
Since linux/if_link.h was synced in libnl commit d533736e2258 ("vxlan:
add support for additional VXLAN attributes."), the minlen check in
validate_nla() fails on kernels < 4.6 - or more precisely, on kernels
not containing kernel commit 6e7333d315a7 ("net: add rx_nohandler stat
counter"). The check fails because rtnl_link_stats and rtnl_link_stats64
sent by the kernel don't have the rx_nohandler member yet, but libnl
expects them to have it.

Account for this by decreasing the minlen by one member and add an
explanatory comment.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>