### PR TITLE
Wire up rx_nohandler in rtnl link stats

### DIFF
--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -98,6 +98,7 @@ typedef enum {
 	RTNL_LINK_IP6_ECT1PKTS,		/*!< IPv6 SNMP InECT1Pkts */
 	RTNL_LINK_IP6_ECT0PKTS,		/*!< IPv6 SNMP InECT0Pkts */
 	RTNL_LINK_IP6_CEPKTS,		/*!< IPv6 SNMP InCEPkts */
+	RTNL_LINK_RX_NOHANDLER,		/*!< Received packets dropped on inactive device */
 	__RTNL_LINK_STATS_MAX,
 } rtnl_link_stat_id_t;
 

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -400,6 +400,11 @@ int rtnl_link_info_parse(struct rtnl_link *link, struct nlattr **tb)
 		/* beware: @st might not be the full struct, only fields up to
 		 * tx_compressed are present. See _nl_offset_plus_sizeof() above. */
 
+		if (nla_len(tb[IFLA_STATS]) > _nl_offset_plus_sizeof (struct rtnl_link_stats, tx_compressed))
+			link->l_stats[RTNL_LINK_RX_NOHANDLER] = st->rx_nohandler;
+		else
+			link->l_stats[RTNL_LINK_RX_NOHANDLER] = 0;
+
 		link->ce_mask |= LINK_ATTR_STATS;
 	}
 
@@ -411,10 +416,9 @@ int rtnl_link_info_parse(struct rtnl_link *link, struct nlattr **tb)
 		 * Therefore, copy the data to the stack and access it from
 		 * there, where it will be aligned to 8.
 		 */
-		struct rtnl_link_stats64 st;
+		struct rtnl_link_stats64 st = { 0 };
 
-		nla_memcpy(&st, tb[IFLA_STATS64], 
-			   sizeof(struct rtnl_link_stats64));
+		nla_memcpy(&st, tb[IFLA_STATS64], nla_len(tb[IFLA_STATS64]));
 
 		link->l_stats[RTNL_LINK_RX_PACKETS]	= st.rx_packets;
 		link->l_stats[RTNL_LINK_TX_PACKETS]	= st.tx_packets;
@@ -445,6 +449,8 @@ int rtnl_link_info_parse(struct rtnl_link *link, struct nlattr **tb)
 
 		/* beware: @st might not be the full struct, only fields up to
 		 * tx_compressed are present. See _nl_offset_plus_sizeof() above. */
+
+		link->l_stats[RTNL_LINK_RX_NOHANDLER]	= st.rx_nohandler;
 
 		link->ce_mask |= LINK_ATTR_STATS;
 	}
@@ -2851,6 +2857,7 @@ static const struct trans_tbl link_stats[] = {
 	__ADD(RTNL_LINK_IP6_ECT1PKTS, Ip6_InECT1Pkts),
 	__ADD(RTNL_LINK_IP6_ECT0PKTS, Ip6_InECT0Pkts),
 	__ADD(RTNL_LINK_IP6_CEPKTS, Ip6_InCEPkts),
+	__ADD(RTNL_LINK_RX_NOHANDLER, rx_nohandler),
 };
 
 char *rtnl_link_stat2str(int st, char *buf, size_t len)

--- a/src/nl-link-stats.c
+++ b/src/nl-link-stats.c
@@ -34,7 +34,7 @@ static void list_stat_names(void)
 	char buf[64];
 	int i;
 
-	for (i = 0; i < RTNL_LINK_STATS_MAX; i++)
+	for (i = 0; i < __RTNL_LINK_STATS_MAX; i++)
 		printf("%s\n", rtnl_link_stat2str(i, buf, sizeof(buf)));
 
 	exit(0);
@@ -59,7 +59,7 @@ static void dump_stats(struct nl_object *obj, void *arg)
 	if (optind >= gargc) {
 		int i;
 
-		for (i = 0; i < RTNL_LINK_STATS_MAX; i++)
+		for (i = 0; i < __RTNL_LINK_STATS_MAX; i++)
 			dump_stat(link, i);
 	} else {
 		while (optind < gargc) {


### PR DESCRIPTION
Hi Thomas,

As a follow-up to #116, here's a PR to add the newly introduced rx_nohandler counter to libnl.

Tested on kernel 4.6 and 4.8 with nl-link-stats (after fixing the off-by-one issue with the stats maximum used to iterate through the stats).

Thanks
Tobias