### PR TITLE
link: fix documentation for rtnl_link_get_carrier_changes

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -2327,8 +2327,9 @@ uint8_t rtnl_link_get_carrier(struct rtnl_link *link)
 /**
  * Return carrier on/off changes of link object
  * @arg link		Link object
+ * @arg carrier_changes	Pointer to store number of carrier changes
  *
- * @return Carrier changes.
+ * @return 0 on success, negative error number otherwise
  */
 int rtnl_link_get_carrier_changes(struct rtnl_link *link, uint32_t *carrier_changes)
 {


### PR DESCRIPTION
Sorry, I was a bit too fast to push out after fixing up the getters in #119. So here's a small fix for the doxygen comment of `rtnl_link_get_carrier_changes`. The doxygen comments for the other newly introduced getters should be correct already.