### PR TITLE
Remove unneeded include in private headers

### DIFF
--- a/include/linux-private/linux/if_bridge.h
+++ b/include/linux-private/linux/if_bridge.h
@@ -15,7 +15,6 @@
 
 #include <linux/types.h>
 #include <linux/if_ether.h>
-#include <linux/in6.h>
 
 #define SYSFS_BRIDGE_ATTR	"bridge"
 #define SYSFS_BRIDGE_FDB	"brforward"


### PR DESCRIPTION
Including linux/in6.h breaks with 3.4 (and earlier?) headers:

In file included from ../include/linux-private/linux/if_bridge.h:18:0, from route/link/bridge.c:26: /usr/include/linux/in6.h:30:8: error: redefinition of 'struct in6_addr'

Also reported at https://bugs.gentoo.org/show_bug.cgi?id=604190