### PR TITLE
route/tc: Remove unused function tca_set_kind()

### DIFF
--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -239,12 +239,6 @@ nla_put_failure:
 	return err;
 }
 
-void tca_set_kind(struct rtnl_tc *t, const char *kind)
-{
-	strncpy(t->tc_kind, kind, sizeof(t->tc_kind) - 1);
-	t->ce_mask |= TCA_ATTR_KIND;
-}
-
 
 /** @endcond */
 


### PR DESCRIPTION
The public prototype and the last internal user of the function were
removed in commit 8eb5b5532e ("Unified TC API") and it was unexported in
commit 4280dfb85d ("build: don't export internal symbols"), so it is
safe to remove it.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>