### PR TITLE
Fix missing/non-matching prototypes

### DIFF
--- a/doc/route.txt
+++ b/doc/route.txt
@@ -1150,10 +1150,10 @@ extern int rtnl_link_ipvti_set_link(struct rtnl_link *link,  uint32_t index);
 extern uint32_t rtnl_link_ipvti_get_link(struct rtnl_link *link);
 
 extern int rtnl_link_ipvti_set_ikey(struct rtnl_link *link, uint32_t ikey);
-extern uint32_t rtnl_link_get_ikey(struct rtnl_link *link);
+extern uint32_t rtnl_link_ipvti_get_ikey(struct rtnl_link *link);
 
 extern int rtnl_link_ipvti_set_okey(struct rtnl_link *link, uint32_t okey);
-extern uint32_t rtnl_link_get_okey(struct rtnl_link *link)
+extern uint32_t rtnl_link_ipvti_get_okey(struct rtnl_link *link)
 
 extern int rtnl_link_ipvti_set_local(struct rtnl_link *link, uint32_t addr);
 extern uint32_t rtnl_link_ipvti_get_local(struct rtnl_link *link);

--- a/include/netlink/fib_lookup/lookup.h
+++ b/include/netlink/fib_lookup/lookup.h
@@ -35,6 +35,13 @@ extern int			flnl_lookup(struct nl_sock *,
 					    struct flnl_request *,
 					    struct nl_cache *);
 
+extern int flnl_result_get_table_id(struct flnl_result *res);
+extern int flnl_result_get_prefixlen(struct flnl_result *res);
+extern int flnl_result_get_nexthop_sel(struct flnl_result *res);
+extern int flnl_result_get_type(struct flnl_result *res);
+extern int flnl_result_get_scope(struct flnl_result *res);
+extern int flnl_result_get_error(struct flnl_result *res);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/netlink/idiag/req.h
+++ b/include/netlink/idiag/req.h
@@ -43,6 +43,10 @@ extern int		    idiagnl_req_set_src(struct idiagnl_req *,
 extern struct nl_addr *	    idiagnl_req_get_dst(const struct idiagnl_req *);
 extern int		    idiagnl_req_set_dst(struct idiagnl_req *,
                                                 struct nl_addr *);
+
+extern int		    idiagnl_req_parse(struct nlmsghdr *nlh,
+					      struct idiagnl_req **result);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/netlink/netfilter/exp.h
+++ b/include/netlink/netfilter/exp.h
@@ -82,7 +82,10 @@ extern uint16_t nfnl_exp_get_zone(const struct nfnl_exp *);
 
 extern void nfnl_exp_set_flags(struct nfnl_exp *, uint32_t);
 extern int  nfnl_exp_test_flags(const struct nfnl_exp *);
+extern void nfnl_exp_unset_flags(struct nfnl_exp *exp, uint32_t flags);
 extern uint32_t nfnl_exp_get_flags(const struct nfnl_exp *);
+extern char * nfnl_exp_flags2str(int flags, char *buf, size_t len);
+int nfnl_exp_str2flags(const char *name);
 
 extern void nfnl_exp_set_class(struct nfnl_exp *, uint32_t);
 extern int  nfnl_exp_test_class(const struct nfnl_exp *);

--- a/include/netlink/netfilter/queue_msg.h
+++ b/include/netlink/netfilter/queue_msg.h
@@ -93,6 +93,8 @@ extern unsigned int		nfnl_queue_msg_get_verdict(const struct nfnl_queue_msg *);
 extern struct nl_msg *		nfnl_queue_msg_build_verdict(const struct nfnl_queue_msg *);
 extern int			nfnl_queue_msg_send_verdict(struct nl_sock *,
 							    const struct nfnl_queue_msg *);
+
+extern struct nl_msg *		nfnl_queue_msg_build_verdict_batch(const struct nfnl_queue_msg *msg);
 extern int			nfnl_queue_msg_send_verdict_batch(struct nl_sock *,
 							    const struct nfnl_queue_msg *);
 extern int			nfnl_queue_msg_send_verdict_payload(struct nl_sock *,

--- a/include/netlink/route/link/ipip.h
+++ b/include/netlink/route/link/ipip.h
@@ -18,9 +18,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 	extern struct rtnl_link *rtnl_link_ipip_alloc(void);
 	extern int rtnl_link_ipip_add(struct nl_sock *sk, const char *name);
+
+	extern int rtnl_link_is_ipip(struct rtnl_link *link);
 
 	extern uint32_t rtnl_link_ipip_get_link(struct rtnl_link *link);
 	extern int rtnl_link_ipip_set_link(struct rtnl_link *link,  uint32_t index);

--- a/include/netlink/route/link/ipvti.h
+++ b/include/netlink/route/link/ipvti.h
@@ -21,20 +21,22 @@ extern "C" {
 	extern struct rtnl_link *rtnl_link_ipvti_alloc(void);
 	extern int rtnl_link_ipvti_add(struct nl_sock *sk, const char *name);
 
+	extern int rtnl_link_is_ipvti(struct rtnl_link *link);
+
 	extern int rtnl_link_ipvti_set_link(struct rtnl_link *link,  uint32_t index);
 	extern uint32_t rtnl_link_ipvti_get_link(struct rtnl_link *link);
 
 	extern int rtnl_link_ipvti_set_ikey(struct rtnl_link *link, uint32_t ikey);
-	extern uint32_t rtnl_link_get_ikey(struct rtnl_link *link);
+	extern uint32_t rtnl_link_ipvti_get_ikey(struct rtnl_link *link);
 
 	extern int rtnl_link_ipvti_set_okey(struct rtnl_link *link, uint32_t okey);
-	extern uint32_t rtnl_link_get_okey(struct rtnl_link *link);
+	extern uint32_t rtnl_link_ipvti_get_okey(struct rtnl_link *link);
 
 	extern int rtnl_link_ipvti_set_local(struct rtnl_link *link, uint32_t addr);
-	extern uint32_t rtnl_link_get_local(struct rtnl_link *link);
+	extern uint32_t rtnl_link_ipvti_get_local(struct rtnl_link *link);
 
 	extern int rtnl_link_ipvti_set_remote(struct rtnl_link *link, uint32_t addr);
-	extern uint32_t rtnl_link_get_remote(struct rtnl_link *link);
+	extern uint32_t rtnl_link_ipvti_get_remote(struct rtnl_link *link);
 
 #ifdef __cplusplus
 }

--- a/include/netlink/route/link/sit.h
+++ b/include/netlink/route/link/sit.h
@@ -22,6 +22,8 @@ extern "C" {
 	extern struct rtnl_link *rtnl_link_sit_alloc(void);
 	extern int rtnl_link_sit_add(struct nl_sock *sk, const char *name);
 
+	extern int rtnl_link_is_sit(struct rtnl_link *link);
+
 	extern int rtnl_link_sit_set_link(struct rtnl_link *link,  uint32_t index);
 	extern uint32_t rtnl_link_sit_get_link(struct rtnl_link *link);
 

--- a/include/netlink/route/link/sit.h
+++ b/include/netlink/route/link/sit.h
@@ -26,7 +26,7 @@ extern "C" {
 	extern uint32_t rtnl_link_sit_get_link(struct rtnl_link *link);
 
 	extern int rtnl_link_sit_set_local(struct rtnl_link *link, uint32_t addr);
-	extern uint32_t rtnl_link_get_sit_local(struct rtnl_link *link);
+	extern uint32_t rtnl_link_sit_get_local(struct rtnl_link *link);
 
 	extern int rtnl_link_sit_set_remote(struct rtnl_link *link, uint32_t addr);
 	extern uint32_t rtnl_link_sit_get_remote(struct rtnl_link *link);

--- a/include/netlink/route/link/sriov.h
+++ b/include/netlink/route/link/sriov.h
@@ -126,6 +126,7 @@ extern int rtnl_link_vf_get_vlans(struct rtnl_link_vf *, nl_vf_vlans_t **);
 extern void rtnl_link_vf_set_vlans(struct rtnl_link_vf *, nl_vf_vlans_t *);
 
 extern int rtnl_link_vf_vlan_alloc(nl_vf_vlans_t **, int);
+extern void rtnl_link_vf_vlan_free(nl_vf_vlans_t *vf_vlans);
 extern void rtnl_link_vf_vlan_put(nl_vf_vlans_t *);
 
 /* Utility functions */

--- a/include/netlink/route/qdisc/red.h
+++ b/include/netlink/route/qdisc/red.h
@@ -14,4 +14,7 @@
 
 #include <netlink/netlink.h>
 
+extern  void rtnl_red_set_limit(struct rtnl_qdisc *qdisc, int limit);
+extern int rtnl_red_get_limit(struct rtnl_qdisc *qdisc);
+
 #endif

--- a/include/netlink/xfrm/sa.h
+++ b/include/netlink/xfrm/sa.h
@@ -141,8 +141,8 @@ extern int                      xfrmnl_sa_set_coaddr (struct xfrmnl_sa*, struct 
 extern int                      xfrmnl_sa_get_mark (struct xfrmnl_sa*, unsigned int*, unsigned int*);
 extern int                      xfrmnl_sa_set_mark (struct xfrmnl_sa*, unsigned int, unsigned int);
 
-extern int                      xfrmnl_sa_get_sec_ctx (struct xfrmnl_sa*, unsigned int, unsigned int,
-                                                       unsigned int, unsigned int, char*);
+extern int                      xfrmnl_sa_get_sec_ctx (struct xfrmnl_sa*, unsigned int*, unsigned int*,
+                                                       unsigned int*, unsigned int*, char*);
 extern int                      xfrmnl_sa_set_sec_ctx (struct xfrmnl_sa*, unsigned int, unsigned int,
                                                        unsigned int, unsigned int, const char*);
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 
 AM_CPPFLAGS  =			 	\
-	-Wall \
+	-Wall -Wmissing-prototypes \
 	-I${top_srcdir}/include/linux-private \
 	-I${top_srcdir}/include \
 	-I${top_builddir}/include \

--- a/lib/route/cls/ematch_grammar.l
+++ b/lib/route/cls/ematch_grammar.l
@@ -16,6 +16,9 @@
  #include <netlink/route/cls/ematch.h>
  #include <netlink/route/cls/ematch/cmp.h>
  #include "ematch_syntax.h"
+
+ int ematch_get_column(yyscan_t);
+ void ematch_set_column(int, yyscan_t);
 %}
 
 %option 8bit

--- a/lib/route/link/inet6.c
+++ b/lib/route/link/inet6.c
@@ -13,6 +13,7 @@
 #include <netlink/netlink.h>
 #include <netlink/attr.h>
 #include <netlink/route/rtnl.h>
+#include <netlink/route/link/inet6.h>
 #include <netlink-private/route/link/api.h>
 
 #define I6_ADDR_GEN_MODE_UNKNOWN	UINT8_MAX

--- a/lib/route/link/ipgre.c
+++ b/lib/route/link/ipgre.c
@@ -818,6 +818,10 @@ uint8_t rtnl_link_ipgre_get_pmtudisc(struct rtnl_link *link)
 	return ipgre->pmtudisc;
 }
 
+/* Function prototype for ABI-preserving wrapper (not in public header) to avoid
+ * GCC warning about missing prototype. */
+uint8_t rtnl_link_get_pmtudisc(struct rtnl_link *link);
+
 uint8_t rtnl_link_get_pmtudisc(struct rtnl_link *link)
 {
 	/* rtnl_link_ipgre_get_pmtudisc() was wrongly named. Keep this

--- a/lib/route/link/ipip.c
+++ b/lib/route/link/ipip.c
@@ -28,6 +28,7 @@
 #include <netlink/utils.h>
 #include <netlink/object.h>
 #include <netlink/route/rtnl.h>
+#include <netlink/route/link/ipip.h>
 #include <netlink-private/route/link/api.h>
 #include <linux/if_tunnel.h>
 

--- a/lib/route/link/ipvti.c
+++ b/lib/route/link/ipvti.c
@@ -28,6 +28,7 @@
 #include <netlink/utils.h>
 #include <netlink/object.h>
 #include <netlink/route/rtnl.h>
+#include <netlink/route/link/ipvti.h>
 #include <netlink-private/route/link/api.h>
 #include <linux/if_tunnel.h>
 

--- a/lib/route/link/macsec.c
+++ b/lib/route/link/macsec.c
@@ -27,6 +27,7 @@
 #include <netlink/utils.h>
 #include <netlink/object.h>
 #include <netlink/route/rtnl.h>
+#include <netlink/route/link/macsec.h>
 #include <netlink-private/route/link/api.h>
 #include <netlink-private/utils.h>
 

--- a/lib/route/pktloc_grammar.l
+++ b/lib/route/pktloc_grammar.l
@@ -5,6 +5,9 @@
  #include <netlink/utils.h>
  #include <netlink/route/pktloc.h>
  #include "pktloc_syntax.h"
+
+ int pktloc_get_column(yyscan_t);
+ void pktloc_set_column(int, yyscan_t);
 %}
 
 %option 8bit

--- a/lib/xfrm/ae.c
+++ b/lib/xfrm/ae.c
@@ -123,6 +123,7 @@
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/object.h>
+#include <netlink/xfrm/ae.h>
 #include <linux/xfrm.h>
 
 /** @cond SKIP */

--- a/lib/xfrm/lifetime.c
+++ b/lib/xfrm/lifetime.c
@@ -46,6 +46,7 @@
  * ~~~~
  */
 
+#include <netlink/xfrm/lifetime.h>
 #include <netlink-private/netlink.h>
 
 static void ltime_cfg_destroy(struct xfrmnl_ltime_cfg* ltime)

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -42,6 +42,7 @@
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/object.h>
+#include <netlink/xfrm/sa.h>
 #include <netlink/xfrm/selector.h>
 #include <netlink/xfrm/lifetime.h>
 #include <time.h>

--- a/lib/xfrm/selector.c
+++ b/lib/xfrm/selector.c
@@ -46,6 +46,7 @@
  * ~~~~
  */
 
+#include <netlink/xfrm/selector.h>
 #include <netlink-private/netlink.h>
 
 static void sel_destroy(struct xfrmnl_sel* sel)
@@ -281,7 +282,7 @@ int xfrmnl_sel_get_family(struct xfrmnl_sel *sel)
 	return sel->family;
 }
 
-int xfrmnl_sel_set_family(struct xfrmnl_sel *sel, int family)
+int xfrmnl_sel_set_family(struct xfrmnl_sel *sel, unsigned int family)
 {
 	sel->family = family;
 

--- a/lib/xfrm/template.c
+++ b/lib/xfrm/template.c
@@ -46,6 +46,7 @@
  * ~~~~
  */
 
+#include <netlink/xfrm/template.h>
 #include <netlink-private/netlink.h>
 
 void xfrmnl_user_tmpl_free(struct xfrmnl_user_tmpl* utmpl)
@@ -229,7 +230,7 @@ int xfrmnl_user_tmpl_get_family(struct xfrmnl_user_tmpl *utmpl)
 	return utmpl->family;
 }
 
-int xfrmnl_user_tmpl_set_family(struct xfrmnl_user_tmpl *utmpl, int family)
+int xfrmnl_user_tmpl_set_family(struct xfrmnl_user_tmpl *utmpl, unsigned int family)
 {
 	utmpl->family = family;
 


### PR DESCRIPTION
Hi Thomas

This PR - large in number of commits, not in number of changed lines - fixes GCC -Wmissing-prototypes warnings and adds said flag to the default CPPFLAGS. This should hopefully help to identify potential problems in future additions to the public API (i.e. function name in public header not matching the exported name) and will also help to identify needlessly public functions which can be made static (or be deleted altogether).

I intentionally split the changes per "module", but if you prefer I can also merge patches together. Likewise, if you'd like me to send these to the mailing list for review, let me know.

Thanks
Tobias