### PR TITLE
fopen: add O_CLOEXEC

### DIFF
--- a/lib/route/classid.c
+++ b/lib/route/classid.c
@@ -328,7 +328,7 @@ int rtnl_tc_read_classid_file(void)
 		}
 	}
 
-	if (!(fd = fopen(path, "r"))) {
+	if (!(fd = fopen(path, "re"))) {
 		err = -nl_syserr2nlerr(errno);
 		goto errout;
 	}
@@ -402,7 +402,7 @@ int rtnl_classid_generate(const char *name, uint32_t *result, uint32_t parent)
 	if (build_sysconf_path(&path, "classid") < 0)
 		return -NLE_NOMEM;
 
-	if (!(fd = fopen(path, "a"))) {
+	if (!(fd = fopen(path, "ae"))) {
 		err = -nl_syserr2nlerr(errno);
 		goto errout;
 	}

--- a/lib/route/pktloc.c
+++ b/lib/route/pktloc.c
@@ -109,7 +109,7 @@ static int read_pktlocs(void)
 
 	NL_DBG(2, "Reading packet location file \"%s\"\n", path);
 
-	if (!(fd = fopen(path, "r"))) {
+	if (!(fd = fopen(path, "re"))) {
 		err = -NLE_PKTLOC_FILE;
 		goto errout;
 	}

--- a/lib/route/qdisc/netem.c
+++ b/lib/route/qdisc/netem.c
@@ -901,7 +901,7 @@ int rtnl_netem_set_delay_distribution(struct rtnl_qdisc *qdisc, const char *dist
 
 	for (i = 0; i < ARRAY_SIZE(test_path); i++) {
 		snprintf(name, NAME_MAX, "%s%s%s", test_path[i], dist_type, dist_suffix);
-		if ((f = fopen(name, "r")))
+		if ((f = fopen(name, "re")))
 			break;
 	}
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -75,7 +75,7 @@ int __nl_read_num_str_file(const char *path, int (*cb)(long, const char *))
 	FILE *fd;
 	char buf[128];
 
-	fd = fopen(path, "r");
+	fd = fopen(path, "re");
 	if (fd == NULL)
 		return -nl_syserr2nlerr(errno);
 
@@ -470,7 +470,7 @@ static void get_psched_settings(void)
 		else
 			strncpy(name, "/proc/net/psched", sizeof(name) - 1);
 
-		if ((fd = fopen(name, "r"))) {
+		if ((fd = fopen(name, "re"))) {
 			unsigned int ns_per_usec, ns_per_tick, nom, denom;
 
 			if (fscanf(fd, "%08x %08x %08x %08x",

--- a/src/nl-list-sockets.c
+++ b/src/nl-list-sockets.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
 	FILE *fd;
 	char buf[2048], p[64];
 
-	fd = fopen(PROC_NETLINK, "r");
+	fd = fopen(PROC_NETLINK, "re");
 	if (fd == NULL) {
 		perror("fopen");
 		return -1;


### PR DESCRIPTION
Add O_CLOEXEC to various fopen() calls. This avoids file descriptors
leaking across an exec() boundary in a multi-threaded program. Please
see "man 2 open" for additional information about O_CLOEXEC.

Signed-off-by: Nick Kralevich <nnk@google.com>