### PR TITLE
Little fixes in creation of security policy messages

### DIFF
--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -765,8 +765,7 @@ static int build_xfrm_sp_message(struct xfrmnl_sp *tmpl, int cmd, int flags, str
 	uint32_t                    len;
 	struct nl_addr*             addr;
 
-	if (!(tmpl->ce_mask & XFRM_SP_ATTR_INDEX) ||
-	    !(tmpl->ce_mask & XFRM_SP_ATTR_DIR))
+	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR))
 		return -NLE_MISSING_ATTR;
 
 	memset ((void*)&sp_info, 0, sizeof (sp_info));

--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -765,8 +765,8 @@ static int build_xfrm_sp_message(struct xfrmnl_sp *tmpl, int cmd, int flags, str
 	uint32_t                    len;
 	struct nl_addr*             addr;
 
-	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR) &&
-			(!(tmpl->ce_mask & XFRM_SP_ATTR_INDEX) ||
+	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR) ||
+			(!(tmpl->ce_mask & XFRM_SP_ATTR_INDEX) &&
 			 !(tmpl->ce_mask & XFRM_SP_ATTR_SEL)))
 		return -NLE_MISSING_ATTR;
 
@@ -958,8 +958,8 @@ static int build_xfrm_sp_delete_message(struct xfrmnl_sp *tmpl, int cmd, int fla
 	struct nl_addr*             addr;
 	uint32_t 					len;
 
-	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR) &&
-			(!(tmpl->ce_mask & XFRM_SP_ATTR_INDEX) ||
+	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR) ||
+			(!(tmpl->ce_mask & XFRM_SP_ATTR_INDEX) &&
 			 !(tmpl->ce_mask & XFRM_SP_ATTR_SEL)))
 		return -NLE_MISSING_ATTR;
 

--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -1172,21 +1172,33 @@ int xfrmnl_sp_get_sec_ctx (struct xfrmnl_sp* sp, unsigned int* len, unsigned int
 
 	return 0;
 }
-
-int xfrmnl_sp_set_sec_ctx (struct xfrmnl_sp* sp, unsigned int len, unsigned int exttype, unsigned int alg, unsigned int doi, unsigned int ctx_len, char* ctx_str)
+/**
+ * @brief      Set security context (ctx_str) for XFRM Polixy.
+ *
+ * @param      sp       XFRM Policy
+ * @param[in]  len      !!! depricated unused parameter !!!
+ * @param[in]  exttype  netlink message attribute - probably XFRMA_SEC_CTX
+ * @param[in]  alg      security context algorithm
+ * @param[in]  doi      security context domain interpretation
+ * @param[in]  ctx_len  Length of the context string.
+ * @param      ctx_str  The context string.
+ *
+ * @return     0 if sucessfull, else -1
+ */
+int xfrmnl_sp_set_sec_ctx (struct xfrmnl_sp* sp, unsigned int len __attribute__((unused)), unsigned int exttype, unsigned int alg, unsigned int doi, unsigned int ctx_len, char* ctx_str)
 {
 	/* Free up the old context string and allocate new one */
 	if (sp->sec_ctx)
 		free (sp->sec_ctx);
-	if ((sp->sec_ctx = calloc (1, sizeof (struct xfrmnl_user_sec_ctx) + (sizeof (uint8_t) * ctx_len))) == NULL)
+	if ((sp->sec_ctx = calloc (1, sizeof(struct xfrmnl_user_sec_ctx) + ctx_len)) == NULL)
 		return -1;
 
 	/* Save the new info */
-	sp->sec_ctx->len        =   len;
+	sp->sec_ctx->len        =   sizeof (struct xfrmnl_user_sec_ctx) + ctx_len;
 	sp->sec_ctx->exttype    =   exttype;
 	sp->sec_ctx->ctx_alg    =   alg;
 	sp->sec_ctx->ctx_doi    =   doi;
-	sp->sec_ctx->ctx_len    =   len;
+	sp->sec_ctx->ctx_len    =   ctx_len;
 	memcpy ((void *)sp->sec_ctx->ctx, (void *)ctx_str, sizeof (uint8_t) * ctx_len);
 
 	sp->ce_mask |= XFRM_SP_ATTR_SECCTX;

--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -765,7 +765,9 @@ static int build_xfrm_sp_message(struct xfrmnl_sp *tmpl, int cmd, int flags, str
 	uint32_t                    len;
 	struct nl_addr*             addr;
 
-	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR))
+	if (!(tmpl->ce_mask & XFRM_SP_ATTR_DIR) &&
+			(!(tmpl->ce_mask & XFRM_SP_ATTR_INDEX) ||
+			 !(tmpl->ce_mask & XFRM_SP_ATTR_SEL)))
 		return -NLE_MISSING_ATTR;
 
 	memset ((void*)&sp_info, 0, sizeof (sp_info));

--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -1190,7 +1190,7 @@ int xfrmnl_sp_set_sec_ctx (struct xfrmnl_sp* sp, unsigned int len __attribute__(
 	/* Free up the old context string and allocate new one */
 	if (sp->sec_ctx)
 		free (sp->sec_ctx);
-	if ((sp->sec_ctx = calloc (1, sizeof(struct xfrmnl_user_sec_ctx) + ctx_len)) == NULL)
+	if ((sp->sec_ctx = calloc (1, sizeof (struct xfrmnl_user_sec_ctx) + ctx_len)) == NULL)
 		return -1;
 
 	/* Save the new info */
@@ -1199,7 +1199,7 @@ int xfrmnl_sp_set_sec_ctx (struct xfrmnl_sp* sp, unsigned int len __attribute__(
 	sp->sec_ctx->ctx_alg    =   alg;
 	sp->sec_ctx->ctx_doi    =   doi;
 	sp->sec_ctx->ctx_len    =   ctx_len;
-	memcpy ((void *)sp->sec_ctx->ctx, (void *)ctx_str, sizeof (uint8_t) * ctx_len);
+	memcpy ((void *)sp->sec_ctx->ctx, (void *)ctx_str, ctx_len);
 
 	sp->ce_mask |= XFRM_SP_ATTR_SECCTX;
 

--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -1219,11 +1219,11 @@ int xfrmnl_sp_get_sec_ctx (struct xfrmnl_sp* sp, unsigned int* len, unsigned int
  * @brief      Set security context (ctx_str) for XFRM Polixy.
  *
  * @param      sp       XFRM Policy
- * @param[in]  len      !!! depricated unused parameter !!!
- * @param[in]  exttype  netlink message attribute - probably XFRMA_SEC_CTX
- * @param[in]  alg      security context algorithm
- * @param[in]  doi      security context domain interpretation
- * @param[in]  ctx_len  Length of the context string.
+ * @param      len      !!! depricated unused parameter !!!
+ * @param      exttype  netlink message attribute - probably XFRMA_SEC_CTX
+ * @param      alg      security context algorithm
+ * @param      doi      security context domain interpretation
+ * @param      ctx_len  Length of the context string.
  * @param      ctx_str  The context string.
  *
  * @return     0 if sucessfull, else -1


### PR DESCRIPTION
I stumbled over some "kind-of-bugs" in _libnl/lib/xfrm/sp.c_ which hindered me to create and delete xfrm policies.
1. The check, whether the policy index and direction set (add and delete message) is to restrictive. Policies can be identified either with index and direction or with direction, selector and security context ,where "not set" is valid too (see kernel/net/xfrm/xfrm_user.c -  `xfrm_get_policy(...)` )
2. In xfrmnl_sp_set_sec_ctx the length values were calculated kind of strange. Firstly both parameters should be different and secondly, the length can be calculated directly from length-of-string and `sizeof(struct  xfrmnl_user_sec_ctx)`.
I don't think that anybody allready used `xfrmnl_sp_set_sec_ctx()` because the old version doesn't work, but i decided not to change the interface and only use a compiler attribute to suppress warnings for unused parameter `len`
3. Constructing a delete-message without index, but with selector and security-context wasn't possible. I added the necessary code.