### PR TITLE
lib, src: fix build with uclibc

### DIFF
--- a/lib/utils.c
+++ b/lib/utils.c
@@ -121,6 +121,10 @@ int __nl_read_num_str_file(const char *path, int (*cb)(long, const char *))
 	return 0;
 }
 
+#ifdef __UCLIBC__
+#define strerror_l(e, l) strerror(e)
+#endif
+
 const char *nl_strerror_l(int err)
 {
 	int errno_save = errno;

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -60,6 +60,10 @@ void nl_cli_print_version(void)
 	exit(0);
 }
 
+#ifdef __UCLIBC__
+#define strerror_l(e, l) strerror(e)
+#endif
+
 /**
  * Print error message and quit application
  * @arg err		Error code.


### PR DESCRIPTION
uClibc-ng C library does not implement strerror_l(). Fallback to plain
strerror() to fix the build.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>