### PR TITLE
route/link: add accessor API for IPv6 flags

### DIFF
--- a/include/netlink/route/link/inet6.h
+++ b/include/netlink/route/link/inet6.h
@@ -36,6 +36,16 @@ extern int		rtnl_link_inet6_get_addr_gen_mode(struct rtnl_link *,
 extern int		rtnl_link_inet6_set_addr_gen_mode(struct rtnl_link *,
 							  uint8_t);
 
+extern int		rtnl_link_inet6_get_flags(struct rtnl_link *,
+							  uint32_t *);
+
+extern int		rtnl_link_inet6_set_flags(struct rtnl_link *,
+							  uint32_t);
+
+/* Link Flags Translations */
+extern char *	rtnl_link_inet6_flags2str(int, char *, size_t);
+extern int		rtnl_link_inet6_str2flags(const char *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1032,3 +1032,10 @@ global:
 	rtnl_u32_set_selector;
 } libnl_3_2_28;
 
+libnl_3_4 {
+global:
+	rtnl_link_inet6_flags2str;
+	rtnl_link_inet6_str2flags;
+	rtnl_link_inet6_get_flags;
+	rtnl_link_inet6_set_flags;
+} libnl_3_2_29;


### PR DESCRIPTION
Add functions to access the IPv6 specific flags of a link object.
Also the functions for IPv6 link flags translation are now exported, similar
to the non IPv6 specific translation functions.