### PR TITLE
addr: add AF_VSOCK to translation table

### DIFF
--- a/lib/addr.c
+++ b/lib/addr.c
@@ -1075,6 +1075,9 @@ static const struct trans_tbl afs[] = {
 #ifdef AF_NFC
 	__ADD(AF_NFC,nfc),
 #endif
+#ifdef AF_VSOCK
+	__ADD(AF_VSOCK,vsock),
+#endif
 };
 
 char *nl_af2str(int family, char *buf, size_t size)


### PR DESCRIPTION
Add AF_VSOCK to the address family translation table.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>