### PR TITLE
genl: drop usage of GENL_ID_GENERATE

### DIFF
--- a/include/linux-private/linux/genetlink.h
+++ b/include/linux-private/linux/genetlink.h
@@ -21,12 +21,16 @@ struct genlmsghdr {
 #define GENL_CMD_CAP_DO		0x02
 #define GENL_CMD_CAP_DUMP	0x04
 #define GENL_CMD_CAP_HASPOL	0x08
+#define GENL_UNS_ADMIN_PERM	0x10
 
 /*
  * List of reserved static generic netlink identifiers:
  */
-#define GENL_ID_GENERATE	0
 #define GENL_ID_CTRL		NLMSG_MIN_TYPE
+#define GENL_ID_VFS_DQUOT	(NLMSG_MIN_TYPE + 1)
+#define GENL_ID_PMCRAID		(NLMSG_MIN_TYPE + 2)
+/* must be last reserved + 1 */
+#define GENL_START_ALLOC	(NLMSG_MIN_TYPE + 3)
 
 /**************************************************************************
  * Controller

--- a/lib/genl/family.c
+++ b/lib/genl/family.c
@@ -215,7 +215,7 @@ unsigned int genl_family_get_id(struct genl_family *family)
 	if (family->ce_mask & FAMILY_ATTR_ID)
 		return family->gf_id;
 	else
-		return GENL_ID_GENERATE;
+		return 0;
 }
 
 /**

--- a/lib/genl/mngt.c
+++ b/lib/genl/mngt.c
@@ -313,7 +313,7 @@ int genl_resolve_id(struct genl_ops *ops)
 	int err = 0;
 
 	/* Check if resolved already */
-	if (ops->o_id != GENL_ID_GENERATE)
+	if (ops->o_id != 0)
 		return 0;
 
 	if (!ops->o_name)


### PR DESCRIPTION
After kernel commit a07ea4d9941a ("genetlink: no longer support using
static family IDs"), GENL_ID_GENERATE is no longer exposed to userspace
(and actually should never have been). Update the private header copy of
linux/genetlink.h accordingly. And replace the two occurences of
GENL_ID_GENERATE.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>