### PR TITLE
genl: fix potential NULL pointer in genl_unregister_family()

### DIFF
--- a/lib/genl/mngt.c
+++ b/lib/genl/mngt.c
@@ -193,6 +193,9 @@ int genl_register_family(struct genl_ops *ops)
  */
 int genl_unregister_family(struct genl_ops *ops)
 {
+    if (!ops->o_list)
+        return -NLE_FAILURE;
+
 	nl_list_del(&ops->o_list);
 
 	return 0;


### PR DESCRIPTION
Though this may hardly occur, but it may be better to do this
to avoid application segfault?

Signed-off-by: Yi Wang <wang.yi59@zte.com.cn>