### PR TITLE
cli: include sys/select.h for select(2)

### DIFF
--- a/include/netlink/cli/utils.h
+++ b/include/netlink/cli/utils.h
@@ -24,6 +24,7 @@
 #include <getopt.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 
 #include <netlink/netlink.h>
 #include <netlink/utils.h>


### PR DESCRIPTION
Some of the cli tools use select(2) and its man page states:

  /* According to POSIX.1-2001, POSIX.1-2008 */
  #include <sys/select.h>

Do so and explicitly #include <sys/select.h> in <netlink/cli/utils.h>
instead of relying of getting select(2) via implicit includes. This is
also needed to make libnl compile for Android.

Based on a previous patch by Fredrik Fornwall.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>