### PR TITLE
lib/route/link/vlan.c: fix memory corruption in rtnl_link_vlan_set_egress_map

### DIFF
--- a/lib/route/link/vlan.c
+++ b/lib/route/link/vlan.c
@@ -162,11 +162,11 @@ static int vlan_parse(struct rtnl_link *link, struct nlattr *data,
 			i++;
 		}
 
-		vi->vi_egress_qos = calloc(i, sizeof(struct vlan_map));
+		/* align to have a little reserve */
+		vi->vi_egress_size = (i + 32) & ~31;
+		vi->vi_egress_qos = calloc(vi->vi_egress_size, sizeof(*vi->vi_egress_qos));
 		if (vi->vi_egress_qos == NULL)
 			return -NLE_NOMEM;
-
-		vi->vi_egress_size = i * sizeof(struct vlan_map);
 
 		i = 0;
 		nla_for_each_nested(nla, tb[IFLA_VLAN_EGRESS_QOS], remaining) {
@@ -270,13 +270,13 @@ static int vlan_clone(struct rtnl_link *dst, struct rtnl_link *src)
 		return err;
 	vdst = dst->l_info;
 
-	vdst->vi_egress_qos = calloc(vsrc->vi_negress,
+	vdst->vi_egress_qos = calloc(vsrc->vi_egress_size,
 				     sizeof(struct vlan_map));
 	if (!vdst->vi_egress_qos)
 		return -NLE_NOMEM;
 
 	memcpy(vdst->vi_egress_qos, vsrc->vi_egress_qos,
-	       vsrc->vi_negress * sizeof(struct vlan_map));
+	       vsrc->vi_egress_size * sizeof(struct vlan_map));
 
 	return 0;
 }
@@ -585,11 +585,11 @@ int rtnl_link_vlan_set_egress_map(struct rtnl_link *link, uint32_t from, int to)
 	if (to < 0 || to > VLAN_PRIO_MAX)
 		return -NLE_INVAL;
 
-	if ((vi->vi_negress * sizeof (struct vlan_map)) >= vi->vi_egress_size) {
-		int new_size = vi->vi_egress_size + sizeof (struct vlan_map);
+	if (vi->vi_negress >= vi->vi_egress_size) {
+		int new_size = vi->vi_egress_size + 32;
 		void *ptr;
 
-		ptr = realloc(vi->vi_egress_qos, new_size);
+		ptr = realloc(vi->vi_egress_qos, new_size * sizeof(struct vlan_map));
 		if (!ptr)
 			return -NLE_NOMEM;
 


### PR DESCRIPTION
Hi,

if you set more than four entries for the vlan egress map a memory corruption occurs because
the reallocation does not reserve memory for more than four.

In my use case I've to configure several interfaces where all possible pcp values in the  vlan tag must be mapped in the right way, so eight entries must be set using rtnl_link_vlan_set_egress_map. The issue is reproducible on several platforms (ARM, x86_64, ...)

Fixing the issue by using vi_negress instead of vi_egress_size used by calloc and realloc and removing the magic value "32" which I didn't understand so far what was the background/intention of it. Maybe someone can tell me? :-)

regards Sebastian