### PR TITLE
Enable setting output interface attribute on route objects

### DIFF
--- a/include/netlink-private/types.h
+++ b/include/netlink-private/types.h
@@ -341,6 +341,7 @@ struct rtnl_route
 	struct nl_addr *	rt_src;
 	uint32_t		rt_table;
 	uint32_t		rt_iif;
+	uint32_t		rt_oif;
 	uint32_t		rt_prio;
 	uint32_t		rt_metrics[RTAX_MAX];
 	uint32_t		rt_metrics_mask;

--- a/include/netlink/route/route.h
+++ b/include/netlink/route/route.h
@@ -93,6 +93,8 @@ extern int	rtnl_route_set_pref_src(struct rtnl_route *, struct nl_addr *);
 extern struct nl_addr *rtnl_route_get_pref_src(struct rtnl_route *);
 extern void	rtnl_route_set_iif(struct rtnl_route *, int);
 extern int	rtnl_route_get_iif(struct rtnl_route *);
+extern void	rtnl_route_set_oif(struct rtnl_route *, int);
+extern int	rtnl_route_get_oif(struct rtnl_route *);
 extern int	rtnl_route_get_src_len(struct rtnl_route *);
 extern void	rtnl_route_set_ttl_propagate(struct rtnl_route *route,
 					     uint8_t ttl_prop);

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -861,6 +861,17 @@ int rtnl_route_get_iif(struct rtnl_route *route)
 	return route->rt_iif;
 }
 
+void rtnl_route_set_oif(struct rtnl_route *route, int ifindex)
+{
+	route->rt_oif = ifindex;
+	route->ce_mask |= ROUTE_ATTR_OIF;
+}
+
+int rtnl_route_get_oif(struct rtnl_route *route)
+{
+	return route->rt_oif;
+}
+
 void rtnl_route_add_nexthop(struct rtnl_route *route, struct rtnl_nexthop *nh)
 {
 	nl_list_add_tail(&nh->rtnh_list, &route->rt_nexthops);
@@ -1387,6 +1398,9 @@ int rtnl_route_build_msg(struct nl_msg *msg, struct rtnl_route *route)
 
 	if (route->ce_mask & ROUTE_ATTR_IIF)
 		NLA_PUT_U32(msg, RTA_IIF, route->rt_iif);
+
+	if (route->ce_mask & ROUTE_ATTR_OIF)
+		NLA_PUT_U32(msg, RTA_OIF, route->rt_oif);
 
 	if (route->ce_mask & ROUTE_ATTR_TTL_PROPAGATE)
 		NLA_PUT_U8(msg, RTA_TTL_PROPAGATE, route->rt_ttl_propagate);


### PR DESCRIPTION
Previously, you could not directly set RTA_OIF from the public
route object modification API, this reveals that attribute.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>