### PR TITLE
Fix bug in test-create-bridge.c

### DIFF
--- a/tests/test-create-bridge.c
+++ b/tests/test-create-bridge.c
@@ -67,6 +67,11 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "Link is not a bridge\n");
 		return -2;
 	}
+
+	rtnl_link_put(ltap);
+	nl_cache_refill(sk, link_cache);
+	ltap = rtnl_link_get_by_name(link_cache, TEST_INTERFACE_NAME);
+
 	if(rtnl_link_get_master(ltap) <= 0) {
 		fprintf(stderr, "Interface is not attached to a bridge\n");
 		return -3;


### PR DESCRIPTION
The call to rtnl_link_get_master() at the end of the example can
misleadingly fail because the nl_cache isn't refilled after adding the
test interface to the test bridge.

This commit changes the example to refill the cache before calling
rtnl_link_get_master().