### PR TITLE
route: add separate function to set netem qdisc delay distribution

### DIFF
--- a/include/netlink/route/qdisc/netem.h
+++ b/include/netlink/route/qdisc/netem.h
@@ -66,6 +66,7 @@ extern int rtnl_netem_get_delay_correlation(struct rtnl_qdisc *);
 /* Delay Distribution */
 #define MAXDIST 65536
 extern int rtnl_netem_set_delay_distribution(struct rtnl_qdisc *, const char *);
+extern int rtnl_netem_set_delay_distribution_data(struct rtnl_qdisc *, int16_t *, size_t len);
 extern int rtnl_netem_get_delay_distribution_size(struct rtnl_qdisc *);
 extern int rtnl_netem_get_delay_distribution(struct rtnl_qdisc *, int16_t **);
 


### PR DESCRIPTION
A new function rtnl_netem_set_delay_distribution_data() has been added
to allow the user to pass the delay distribution directly without loading
it from a file.

In conjunction with the maketable code (see iproute2 / NISTnet) this can
be used to generate and load custom delay distributions on the fly.