### PR TITLE
tests: Add test to {de}activate loopback interface

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -813,7 +813,8 @@ check_PROGRAMS += \
 	tests/test-create-vxlan \
 	tests/test-delete-link \
 	tests/test-socket-creation \
-	tests/test-u32-filter-with-actions
+	tests/test-u32-filter-with-actions \
+	tests/test-loopback-up-down
 
 tests_test_create_bond_CPPFLAGS                   = $(tests_cppflags)
 tests_test_create_bond_LDADD                      = $(tests_ldadd)
@@ -857,6 +858,8 @@ tests_test_complex_HTB_with_hash_filters_CPPFLAGS = $(tests_cppflags)
 tests_test_complex_HTB_with_hash_filters_LDADD    = $(tests_ldadd)
 tests_test_u32_filter_with_actions_CPPFLAGS       = $(tests_cppflags)
 tests_test_u32_filter_with_actions_LDADD          = $(tests_ldadd)
+tests_test_loopback_up_down_CPPFLAGS              = $(tests_cppflags)
+tests_test_loopback_up_down_LDADD                 = $(tests_ldadd)
 
 check_PROGRAMS += \
 	tests/test-cache-mngr \

--- a/tests/test-loopback-up-down.c
+++ b/tests/test-loopback-up-down.c
@@ -1,0 +1,54 @@
+#include <net/if.h>
+#include <netlink/route/link.h>
+
+int main(void)
+{
+	struct nl_sock *sk;
+	struct rtnl_link *link, *change;
+	struct nl_cache *cache;
+	int err = 0;
+
+	sk = nl_socket_alloc();
+	if ((err = nl_connect(sk, NETLINK_ROUTE)) < 0) {
+		nl_perror(err, "Unable to connect socket");
+		return err;
+	}
+
+	if ((err = rtnl_link_alloc_cache(sk, AF_UNSPEC, &cache)) < 0) {
+		nl_perror(err, "Unable to allocate cache");
+		goto out;
+	}
+
+	if (!(link = rtnl_link_get_by_name(cache, "lo"))) {
+		fprintf(stderr, "Interface not found\n");
+		err = 1;
+		goto out;
+	}
+
+	/* exit if the loopback interface is already deactivated */
+	err = rtnl_link_get_flags(link);
+	if (!(err & IFF_UP)) {
+		err = 0;
+		goto out;
+	}
+
+	change = rtnl_link_alloc();
+	rtnl_link_unset_flags(change, IFF_UP);
+
+	if ((err = rtnl_link_change(sk, link, change, 0)) < 0) {
+		nl_perror(err, "Unable to deactivate lo");
+		goto out;
+	}
+
+	rtnl_link_set_flags(change, IFF_UP);
+	if ((err = rtnl_link_change(sk, link, change, 0)) < 0) {
+		nl_perror(err, "Unable to activate lo");
+		goto out;
+	}
+
+	err = 0;
+
+out:
+	nl_socket_free(sk);
+	return err;
+}


### PR DESCRIPTION
This tests is much more like an example of how to do it, and also works
as a test to check if rtnl_link_change is working as expected when it
comes to loopback interface.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>