### PR TITLE
Add new function for setting parent of classifier cache.

### DIFF
--- a/include/netlink/route/classifier.h
+++ b/include/netlink/route/classifier.h
@@ -27,6 +27,8 @@ extern void		rtnl_cls_put(struct rtnl_cls *);
 extern int		rtnl_cls_alloc_cache(struct nl_sock *, int, uint32_t,
 					     struct nl_cache **);
 
+extern void 		rtnl_cls_cache_set_tcm_params(struct nl_cache *, int, uint32_t);
+
 extern int		rtnl_cls_build_add_request(struct rtnl_cls *, int,
 						   struct nl_msg **);
 extern int		rtnl_cls_add(struct nl_sock *, struct rtnl_cls *, int);

--- a/lib/route/cls.c
+++ b/lib/route/cls.c
@@ -345,6 +345,24 @@ int rtnl_cls_alloc_cache(struct nl_sock *sk, int ifindex, uint32_t parent,
 	return 0;
 }
 
+/**
+ * Set interface index and parent handle for classifier cache.
+ * @arg cache 		Pointer to cache
+ * @arg parent 		Parent qdisc/traffic class class
+ *
+ * Set the interface index and parent handle of a classifier cache.
+ * This is useful for reusing some existed classifier cache to reduce
+ * the overhead introduced by memory allocation.
+ *
+ * @return void.
+ */
+void rtnl_cls_cache_set_tcm_params(struct nl_cache *cache,
+				   int ifindex, uint32_t parent)
+{
+	cache->c_iarg1 = ifindex;
+	cache->c_iarg2 = parent;
+}
+
 /** @} */
 
 static void cls_dump_line(struct rtnl_tc *tc, struct nl_dump_params *p)

--- a/lib/route/cls.c
+++ b/lib/route/cls.c
@@ -324,7 +324,8 @@ int rtnl_cls_delete(struct nl_sock *sk, struct rtnl_cls *cls, int flags)
  *
  * @return 0 on success or a negative error code.
  */
-int rtnl_cls_alloc_cache(struct nl_sock *sk, int ifindex, uint32_t parent,			 struct nl_cache **result)
+int rtnl_cls_alloc_cache(struct nl_sock *sk, int ifindex, uint32_t parent,
+			 struct nl_cache **result)
 {
 	struct nl_cache * cache;
 	int err;

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -151,6 +151,7 @@ global:
 	rtnl_cls_add;
 	rtnl_cls_alloc;
 	rtnl_cls_alloc_cache;
+	rtnl_cls_cache_set_tcm_params;
 	rtnl_cls_build_add_request;
 	rtnl_cls_build_change_request;
 	rtnl_cls_build_delete_request;


### PR DESCRIPTION
It is not good to give classifier cache users only one chance to set parent id when allocte new cache. Sometimes we want to reuse classifier cache to reduce the overhead of allocating new memory everytime a new cache is created.