### PR TITLE
Dirty fix for libnl cgroup filter addition problem.

### DIFF
--- a/include/netlink/attr.h
+++ b/include/netlink/attr.h
@@ -143,6 +143,7 @@ extern int		nla_put_nested(struct nl_msg *, int,
 				       const struct nl_msg *);
 extern struct nlattr *	nla_nest_start(struct nl_msg *, int);
 extern int		nla_nest_end(struct nl_msg *, struct nlattr *);
+extern int		nla_nest_end_keep_empty(struct nl_msg *, struct nlattr *);
 extern void		nla_nest_cancel(struct nl_msg *, const struct nlattr *);
 extern int		nla_parse_nested(struct nlattr **, int, struct nlattr *,
 					 const struct nla_policy *);

--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -226,7 +226,10 @@ int rtnl_tc_msg_build(struct rtnl_tc *tc, int type, int flags,
 			if ((err = ops->to_msg_fill(tc, data, msg)) < 0)
 				goto nla_put_failure;
 
-			nla_nest_end(msg, opts);
+			if (strcmp("cgroup", tc->tc_kind))
+				nla_nest_end(msg, opts);
+			else
+				nla_nest_end_keep_empty(msg, opts);
 		} else if ((err = ops->to_msg_fill_raw(tc, data, msg)) < 0)
 			goto nla_put_failure;
 	}

--- a/libnl-3.sym
+++ b/libnl-3.sym
@@ -260,6 +260,7 @@ global:
 	nla_memcpy;
 	nla_nest_cancel;
 	nla_nest_end;
+	nla_nest_end_keep_empty;
 	nla_nest_start;
 	nla_next;
 	nla_ok;


### PR DESCRIPTION
Currently, due to the incomplete netlink datagram sent by libnl, cgroup
filter addition is not fully functional. The datagram generated by `tc`
command includes an empty attribute section, which is stripped off
in the libnl counterpart.

In this dirty fix, we selectively disable the deletion for `cgroup`
filter.