### PR TITLE
Demo tool that prints conntrack events

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -628,6 +628,7 @@ cli_programs = \
 	src/idiag-socket-details \
 	src/nf-ct-add \
 	src/nf-ct-list \
+	src/nf-ct-events \
 	src/nf-exp-add \
 	src/nf-exp-delete \
 	src/nf-exp-list \
@@ -691,6 +692,8 @@ src_idiag_socket_details_CPPFLAGS = $(src_cppflags)
 src_idiag_socket_details_LDADD =    $(src_ldadd)
 src_nf_ct_add_CPPFLAGS =            $(src_cppflags)
 src_nf_ct_add_LDADD =               $(src_ldadd)
+src_nf_ct_events_CPPFLAGS =         $(src_cppflags)
+src_nf_ct_events_LDADD =            $(src_ldadd)
 src_nf_ct_list_CPPFLAGS =           $(src_cppflags)
 src_nf_ct_list_LDADD =              $(src_ldadd)
 src_nf_exp_add_CPPFLAGS =           $(src_cppflags)

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,5 @@
 genl-ctrl-list
-/nf-ct-add
+nf-ct-add
 nf-ct-list
 nf-ct-events
 nf-exp-list

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,6 +1,7 @@
 genl-ctrl-list
 /nf-ct-add
 nf-ct-list
+nf-ct-events
 nf-exp-list
 nf-exp-add
 nf-exp-delete

--- a/src/nf-ct-add.c
+++ b/src/nf-ct-add.c
@@ -1,5 +1,5 @@
 /*
- * src/nf-ct-list.c     List Conntrack Entries
+ * src/nf-ct-add.c     Add Conntrack Entry
  *
  *	This library is free software; you can redistribute it and/or
  *	modify it under the terms of the GNU Lesser General Public

--- a/src/nf-ct-events.c
+++ b/src/nf-ct-events.c
@@ -1,0 +1,115 @@
+/*
+ * src/nf-ct-events.c	  Listen on Conntrack Events
+ *
+ *	This library is free software; you can redistribute it and/or
+ *	modify it under the terms of the GNU Lesser General Public
+ *	License as published by the Free Software Foundation version 2.1
+ *	of the License.
+ *
+ * Copyright (c) 2018 Avast software
+ */
+
+#include <netlink/cli/utils.h>
+#include <netlink/cli/ct.h>
+
+#include <linux/netlink.h>
+#include <linux/netfilter/nfnetlink.h>
+#include <linux/netfilter/nfnetlink_conntrack.h>
+
+struct private_nl_object
+{
+	int			ce_refcnt;
+	struct nl_object_ops *	ce_ops;
+	struct nl_cache *	ce_cache;
+	struct nl_list_head	ce_list;
+	int			ce_msgtype;
+	int			ce_flags;
+	uint64_t		ce_mask;
+};
+
+static void nf_conntrack_parse_callback(struct nl_object *obj, void *opaque)
+{
+	struct nl_dump_params params = {
+		.dp_fd = stdout,
+		.dp_type = NL_DUMP_DETAILS,
+	};
+
+	nl_object_dump(obj, &params);
+}
+
+static int nf_conntrack_event_callback(struct nl_msg *msg, void *opaque)
+{
+	int err;
+	struct nlmsghdr *hdr = nlmsg_hdr(msg);
+
+	enum cntl_msg_types type = (enum cntl_msg_types) NFNL_MSG_TYPE(hdr->nlmsg_type);
+
+	int flags = hdr->nlmsg_flags;
+
+	if (type == IPCTNL_MSG_CT_DELETE) {
+		printf("DELETE ");
+	} else if (type == IPCTNL_MSG_CT_NEW) {
+		if (flags & (NLM_F_CREATE|NLM_F_EXCL)) {
+			printf("NEW ");
+		} else {
+			printf("UPDATE ");
+		}
+	} else {
+		printf("UNKNOWN ");
+	}
+
+	if ((err = nl_msg_parse(msg, &nf_conntrack_parse_callback, opaque)) < 0) {
+		nl_cli_fatal(err, "nl_msg_parse: %s", nl_geterror(err));
+	}
+	/* Continue with next event */
+	return NL_OK;
+}
+
+int main(int argc, char *argv[])
+{
+	struct nl_sock *socket;
+	int err;
+
+	socket = nl_cli_alloc_socket();
+	if (socket == NULL) {
+		nl_cli_fatal(ENOBUFS, "Unable to allocate netlink socket");
+	}
+
+	/*
+	 * Disable sequence number checking.
+	 * This is required to allow messages to be processed which were not requested by
+	 * a preceding request message, e.g. netlink events.
+	 */
+	nl_socket_disable_seq_check(socket);
+
+	/* subscribe conntrack events */
+	nl_join_groups(socket, NF_NETLINK_CONNTRACK_NEW |
+												 NF_NETLINK_CONNTRACK_UPDATE |
+												 NF_NETLINK_CONNTRACK_DESTROY |
+												 NF_NETLINK_CONNTRACK_EXP_NEW |
+												 NF_NETLINK_CONNTRACK_EXP_UPDATE |
+												 NF_NETLINK_CONNTRACK_EXP_DESTROY);
+
+	nl_cli_connect(socket, NETLINK_NETFILTER);
+
+	nl_socket_modify_cb(socket, NL_CB_VALID, NL_CB_CUSTOM, &nf_conntrack_event_callback, 0);
+
+	while (1) {
+
+		errno = 0;
+		if ((err = nl_recvmsgs_default(socket)) < 0) {
+			switch (errno) {
+				case 	ENOBUFS:
+					// just print warning
+					fprintf(stderr, "Lost events because of ENOBUFS\n");
+					break;
+				case EAGAIN:
+				case EINTR:
+					// continue reading
+					break;
+				default:
+					nl_cli_fatal(err, "Failed to receive: %s", nl_geterror(err));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi.

This is just simple tool `nf-ct-events` that shows howto listen and dump conntrack events. I requested such example few days ago https://github.com/thom311/libnl/issues/171 , I believe that it may be useful to others.

Sample output:
```
DELETE igmp 172.30.251.226 <-> 224.0.0.251 
    id 0x5501b80 family inet <NOREPLY,DYING>
NEW udp 10.7.32.56:53632 <-> 239.255.255.250:1900 
    id 0x4f4ab2c0 family inet timeout 30s <NOREPLY>
DELETE udp 172.30.254.111:60844 <-> 239.255.255.250:1900 
    id 0xb3f5d040 family inet <NOREPLY,DYING>
DELETE udp 172.30.255.209:5353 <-> 224.0.0.251:5353 
    id 0x2d072f00 family inet <NOREPLY,DYING>
DELETE udp 10.7.33.237:137 <-> 10.7.35.255:137 
    id 0x2d26ec80 family inet <NOREPLY,DYING>
NEW udp 172.30.248.139:41353 <-> 239.255.255.250:1900 
    id 0xcab39180 family inet timeout 30s <NOREPLY>
```