### PR TITLE
build: fix build on musl libc

### DIFF
--- a/include/linux-private/linux/if_ether.h
+++ b/include/linux-private/linux/if_ether.h
@@ -22,6 +22,7 @@
 #define _LINUX_IF_ETHER_H
 
 #include <linux/types.h>
+#include <linux/libc-compat.h>
 
 /*
  *	IEEE 802.3 Ethernet magic constants.  The frame sizes omit the preamble
@@ -117,10 +118,12 @@
  *	This is an Ethernet frame header.
  */
 
+#if __UAPI_DEF_ETHHDR
 struct ethhdr {
 	unsigned char	h_dest[ETH_ALEN];	/* destination eth addr	*/
 	unsigned char	h_source[ETH_ALEN];	/* source ether addr	*/
 	__be16		h_proto;		/* packet type ID field	*/
 } __attribute__((packed));
+#endif
 
 #endif	/* _LINUX_IF_ETHER_H */

--- a/include/linux-private/linux/libc-compat.h
+++ b/include/linux-private/linux/libc-compat.h
@@ -48,10 +48,18 @@
 #ifndef _LIBC_COMPAT_H
 #define _LIBC_COMPAT_H
 
-/* We have included glibc headers... */
-#if defined(__GLIBC__)
+/* We're used from userspace... */
+#if !defined(__KERNEL__)
 
-/* Coordinate with glibc netinet/in.h header. */
+/* Coordinate with libc netinet/if_ether.h */
+#ifdef _NETINET_IF_ETHER_H /* musl */
+#define __UAPI_DEF_ETHHDR 0
+#else
+/* glibc uses __NETINET_IF_ETHER_H, and uses the uapi header. */
+#define __UAPI_DEF_ETHHDR 1
+#endif
+
+/* Coordinate with libc netinet/in.h header. */
 #if defined(_NETINET_IN_H)
 
 /* GLIBC headers included first so don't define anything
@@ -64,15 +72,7 @@
 #define __UAPI_DEF_IN_CLASS		0
 
 #define __UAPI_DEF_IN6_ADDR		0
-/* The exception is the in6_addr macros which must be defined
- * if the glibc code didn't define them. This guard matches
- * the guard in glibc/inet/netinet/in.h which defines the
- * additional in6_addr macros e.g. s6_addr16, and s6_addr32. */
-#if defined(__USE_MISC) || defined (__USE_GNU)
 #define __UAPI_DEF_IN6_ADDR_ALT		0
-#else
-#define __UAPI_DEF_IN6_ADDR_ALT		1
-#endif
 #define __UAPI_DEF_SOCKADDR_IN6		0
 #define __UAPI_DEF_IPV6_MREQ		0
 #define __UAPI_DEF_IPPROTO_V6		0
@@ -83,7 +83,7 @@
 #else
 
 /* Linux headers included first, and we must define everything
- * we need. The expectation is that glibc will check the
+ * we need. The expectation is that libc will check the
  * __UAPI_DEF_* defines and adjust appropriately. */
 #define __UAPI_DEF_IN_ADDR		1
 #define __UAPI_DEF_IN_IPPROTO		1
@@ -93,7 +93,7 @@
 #define __UAPI_DEF_IN_CLASS		1
 
 #define __UAPI_DEF_IN6_ADDR		1
-/* We unconditionally define the in6_addr macros and glibc must
+/* We unconditionally define the in6_addr macros and libc must
  * coordinate. */
 #define __UAPI_DEF_IN6_ADDR_ALT		1
 #define __UAPI_DEF_SOCKADDR_IN6		1
@@ -115,7 +115,10 @@
 /* If we did not see any headers from any supported C libraries,
  * or we are being included in the kernel, then define everything
  * that we need. */
-#else /* !defined(__GLIBC__) */
+#else /* defined(__KERNEL__) */
+
+/* Definitions for if/ether.h */
+#define  __UAPI_DEF_ETHHDR		1
 
 /* Definitions for in.h */
 #define __UAPI_DEF_IN_ADDR		1
@@ -138,6 +141,6 @@
 /* Definitions for xattr.h */
 #define __UAPI_DEF_XATTR		1
 
-#endif /* __GLIBC__ */
+#endif /* defined(__KERNEL__) */
 
 #endif /* _LIBC_COMPAT_H */


### PR DESCRIPTION
This PR fixes portability problems such as dependencies on glibc macros. This patch has been tested against musl and glibc, and builds with no issues.