### PR TITLE
neigh: set correct AF for NDA_DST

### DIFF
--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -389,11 +389,13 @@ int rtnl_neigh_parse(struct nlmsghdr *n, struct rtnl_neigh **result)
 	}
 
 	if (tb[NDA_DST]) {
-		neigh->n_dst = nl_addr_alloc_attr(tb[NDA_DST], neigh->n_family);
+		neigh->n_dst = nl_addr_alloc_attr(tb[NDA_DST], AF_UNSPEC);
 		if (!neigh->n_dst) {
 			err = -NLE_NOMEM;
 			goto errout;
 		}
+		nl_addr_set_family(neigh->n_dst,
+				   nl_addr_guess_family(neigh->n_dst));
 		neigh->ce_mask |= NEIGH_ATTR_DST;
 	}
 


### PR DESCRIPTION
In case using a VXLAN interface at a bridge you will set L2 bridging
entries using a IP destination to tunnel the according L2 traffic. The
current behavior for the dst entries for a neighbor is to use the AF of
the neighbor itself thus in this case AF_BRIDGE is set. This is changed
in the PR to update the family of the dst using nl_addr_guess_family.