### PR TITLE
neigh: support bridge entries for vxlan interfaces

### DIFF
--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -319,11 +319,13 @@ static uint32_t neigh_id_attrs_get(struct nl_object *obj)
 
 	if (neigh->n_family == AF_BRIDGE) {
 		if (neigh->n_flags & NTF_SELF)
-			return (NEIGH_ATTR_LLADDR | NEIGH_ATTR_FAMILY | NEIGH_ATTR_IFINDEX | NEIGH_ATTR_VLAN);
+			return (NEIGH_ATTR_LLADDR | NEIGH_ATTR_FAMILY | NEIGH_ATTR_IFINDEX |
+				       ((neigh->ce_mask & NEIGH_ATTR_DST) ? NEIGH_ATTR_DST: 0) |
+				       ((neigh->ce_mask & NEIGH_ATTR_VLAN) ? NEIGH_ATTR_VLAN : 0));
 		else
 			return (NEIGH_ATTR_LLADDR | NEIGH_ATTR_FAMILY | NEIGH_ATTR_MASTER | NEIGH_ATTR_VLAN);
 	} else
-		return (NEIGH_ATTR_IFINDEX | NEIGH_ATTR_DST | NEIGH_ATTR_FAMILY);
+		return neigh_obj_ops.oo_id_attrs;
 }
 
 static struct nla_policy neigh_policy[NDA_MAX+1] = {


### PR DESCRIPTION
bridge entries used for switching into vxlan interfaces do not include a
vlan. A comparison of such entires currently always fails which leads
to an invalid cache. This patch selectively adds the NEIGH_ATTR_VLAN
flag based on the passed entry.