### PR TITLE
Add new api rtnl_class_get_by_parent()

### DIFF
--- a/include/netlink/route/class.h
+++ b/include/netlink/route/class.h
@@ -31,6 +31,9 @@ extern int		rtnl_class_alloc_cache(struct nl_sock *, int,
 extern struct rtnl_class *
 			rtnl_class_get(struct nl_cache *, int, uint32_t);
 
+extern struct rtnl_class *
+			rtnl_class_get_by_parent(struct nl_cache *, int, uint32_t);
+
 extern struct rtnl_qdisc *
 			rtnl_class_leaf_qdisc(struct rtnl_class *,
 						      struct nl_cache *);

--- a/lib/route/class.c
+++ b/lib/route/class.c
@@ -367,6 +367,38 @@ struct rtnl_class *rtnl_class_get(struct nl_cache *cache, int ifindex,
 	return NULL;
 }
 
+/**
+ * Search class by interface index and parent
+ * @arg cache		Traffic class cache
+ * @arg ifindex		Interface index
+ * @arg parent		Handle of parent qdisc
+ *
+ * Searches a class cache previously allocated with rtnl_class_alloc_cache()
+ * and searches for a class matching the interface index and parent qdisc.
+ *
+ * The reference counter is incremented before returning the class, therefore
+ * the reference must be given back with rtnl_class_put() after usage.
+ *
+ * @return pointer to class inside the cache or NULL if no match was found.
+ */
+struct rtnl_class *rtnl_class_get_by_parent(struct nl_cache *cache, int ifindex,
+					    uint32_t parent)
+{
+	struct rtnl_class *class;
+
+	if (cache->c_ops != &rtnl_class_ops)
+		return NULL;
+
+	nl_list_for_each_entry(class, &cache->c_items, ce_list) {
+		if (class->c_parent == parent && class->c_ifindex == ifindex) {
+			nl_object_get((struct nl_object *) class);
+			return class;
+		}
+	}
+
+	return NULL;
+}
+
 /** @} */
 
 /**

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1064,6 +1064,7 @@ global:
 
 libnl_3_5 {
 global:
+	rtnl_class_get_by_parent;
 	rtnl_cls_cache_set_tc_params;
 	rtnl_netem_set_delay_distribution_data;
 	rtnl_link_is_geneve;


### PR DESCRIPTION
This function searches a class cache previously allocated with rtnl_class_alloc_cache()
and searches for a class matching the interface index and parent qdisc.