### PR TITLE
neigh: update neighbour.h and add missing flags

### DIFF
--- a/include/linux-private/linux/neighbour.h
+++ b/include/linux-private/linux/neighbour.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 #ifndef __LINUX_NEIGHBOUR_H
 #define __LINUX_NEIGHBOUR_H
 
@@ -25,6 +26,8 @@ enum {
 	NDA_VNI,
 	NDA_IFINDEX,
 	NDA_MASTER,
+	NDA_LINK_NETNSID,
+	NDA_SRC_VNI,
 	__NDA_MAX
 };
 
@@ -38,6 +41,8 @@ enum {
 #define NTF_SELF	0x02
 #define NTF_MASTER	0x04
 #define NTF_PROXY	0x08	/* == ATF_PUBL */
+#define NTF_EXT_LEARNED	0x10
+#define NTF_OFFLOADED   0x20
 #define NTF_ROUTER	0x80
 
 /*
@@ -58,7 +63,7 @@ enum {
 
 /* NUD_NOARP & NUD_PERMANENT are pseudostates, they never change
    and make no address resolution or NUD.
-   NUD_PERMANENT is also cannot be deleted by garbage collectors.
+   NUD_PERMANENT also cannot be deleted by garbage collectors.
  */
 
 struct nda_cacheinfo {
@@ -104,6 +109,7 @@ struct ndt_stats {
 	__u64		ndts_rcv_probes_ucast;
 	__u64		ndts_periodic_gc_runs;
 	__u64		ndts_forced_gc_runs;
+	__u64		ndts_table_fulls;
 };
 
 enum {
@@ -123,6 +129,9 @@ enum {
 	NDTPA_PROXY_DELAY,		/* u64, msecs */
 	NDTPA_PROXY_QLEN,		/* u32 */
 	NDTPA_LOCKTIME,			/* u64, msecs */
+	NDTPA_QUEUE_LENBYTES,		/* u32 */
+	NDTPA_MCAST_REPROBES,		/* u32 */
+	NDTPA_PAD,
 	__NDTPA_MAX
 };
 #define NDTPA_MAX (__NDTPA_MAX - 1)
@@ -155,6 +164,7 @@ enum {
 	NDTA_PARMS,			/* nested TLV NDTPA_* */
 	NDTA_STATS,			/* struct ndt_stats, read-only */
 	NDTA_GC_INTERVAL,		/* u64, msecs */
+	NDTA_PAD,
 	__NDTA_MAX
 };
 #define NDTA_MAX (__NDTA_MAX - 1)

--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -861,6 +861,9 @@ static const struct trans_tbl neigh_flags[] = {
 	__ADD(NTF_PROXY, proxy),
 	__ADD(NTF_ROUTER, router),
 	__ADD(NTF_SELF, self),
+	__ADD(NTF_MASTER, master),
+	__ADD(NTF_EXT_LEARNED, ext_learned),
+	__ADD(NTF_OFFLOADED, offloaded),
 };
 
 char * rtnl_neigh_flags2str(int flags, char *buf, size_t len)


### PR DESCRIPTION
NTF_EXT_LEARNED, NTF_OFFLOADED and NTF_MASTER are added to neigh_flags.