### PR TITLE
neigh: add get/set functions for NEIGH_ATTR_MASTER

### DIFF
--- a/include/netlink/route/neighbour.h
+++ b/include/netlink/route/neighbour.h
@@ -82,6 +82,9 @@ extern int			rtnl_neigh_get_family(struct rtnl_neigh *);
 extern void			rtnl_neigh_set_vlan(struct rtnl_neigh *, int);
 extern int			rtnl_neigh_get_vlan(struct rtnl_neigh *);
 
+extern void			rtnl_neigh_set_master(struct rtnl_neigh *, int);
+extern int			rtnl_neigh_get_master(struct rtnl_neigh *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -1023,6 +1023,16 @@ int rtnl_neigh_get_vlan(struct rtnl_neigh *neigh)
 		return -1;
 }
 
+void rtnl_neigh_set_master(struct rtnl_neigh *neigh, int ifindex)
+{
+	neigh->n_master = ifindex;
+	neigh->ce_mask |= NEIGH_ATTR_MASTER;
+}
+
+int rtnl_neigh_get_master(struct rtnl_neigh *neigh) {
+	return neigh->n_master;
+}
+
 /** @} */
 
 static struct nl_object_ops neigh_obj_ops = {

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1106,4 +1106,6 @@ global:
 	rtnl_mall_append_action;
 	rtnl_mall_get_first_action;
 	rtnl_mall_del_action;
+	rtnl_neigh_get_master;
+	rtnl_neigh_set_master;
 } libnl_3_4;


### PR DESCRIPTION
Beeing able to set NEIGH_ATTR_MASTER hash based lookups are possible for
AF_BRIDGE neighbours.