### PR TITLE
nla_ok: fix overrun in attribute iteration.

### DIFF
--- a/lib/attr.c
+++ b/lib/attr.c
@@ -147,7 +147,7 @@ int nla_len(const struct nlattr *nla)
  */
 int nla_ok(const struct nlattr *nla, int remaining)
 {
-	return remaining >= sizeof(*nla) &&
+	return remaining >= (int) sizeof(*nla) &&
 	       nla->nla_len >= sizeof(*nla) &&
 	       nla->nla_len <= remaining;
 }


### PR DESCRIPTION
A detailed explanation is provided in the original Linux kernel commit that
fixes the bug: 1045b03e07d85f3545118510a587035536030c1c

Valgrind spotted the issue when the remaining was negative.
This bug was triggering application crashes.

Signed-off-by: Patrick Havelange <patrick.havelange@tessares.net>