### PR TITLE
Fix potential memory leak in route/cls

### DIFF
--- a/lib/route/cls/basic.c
+++ b/lib/route/cls/basic.c
@@ -220,6 +220,7 @@ struct rtnl_ematch_tree *rtnl_basic_get_ematch(struct rtnl_cls *cls)
 int rtnl_basic_add_action(struct rtnl_cls *cls, struct rtnl_act *act)
 {
 	struct rtnl_basic *b;
+	int err;
 
 	if (!act)
 		return 0;
@@ -228,9 +229,12 @@ int rtnl_basic_add_action(struct rtnl_cls *cls, struct rtnl_act *act)
 		return -NLE_NOMEM;
 
 	b->b_mask |= BASIC_ATTR_ACTION;
+	if ((err = rtnl_act_append(&b->b_act, act)))
+		return err;
+
 	/* In case user frees it */
 	rtnl_act_get(act);
-	return rtnl_act_append(&b->b_act, act);
+	return 0;
 }
 
 struct rtnl_act* rtnl_basic_get_action(struct rtnl_cls *cls)

--- a/lib/route/cls/u32.c
+++ b/lib/route/cls/u32.c
@@ -526,6 +526,7 @@ int rtnl_u32_set_cls_terminal(struct rtnl_cls *cls)
 int rtnl_u32_add_action(struct rtnl_cls *cls, struct rtnl_act *act)
 {
 	struct rtnl_u32 *u;
+	int err;
 
 	if (!act)
 		return 0;
@@ -534,9 +535,12 @@ int rtnl_u32_add_action(struct rtnl_cls *cls, struct rtnl_act *act)
 		return -NLE_NOMEM;
 
 	u->cu_mask |= U32_ATTR_ACTION;
+	if ((err = rtnl_act_append(&u->cu_act, act)))
+		return err;
+
 	/* In case user frees it */
 	rtnl_act_get(act);
-	return rtnl_act_append(&u->cu_act, act);
+	return 0;
 }
 
 struct rtnl_act* rtnl_u32_get_action(struct rtnl_cls *cls)


### PR DESCRIPTION
Commit e5d9b828f6ec64fd77854578fbf1c33f214f3ac4 added reference grabbing for actions that are added to the filter before inserting them to the list. `rtnl_act_append()` fails when it tries to add more than `TCA_ACT_MAX_PRIO` actions to the same list. Because of that `rtnl_basic_add_action()` and `rtnl_u32_add_action()` should not increment the reference counter of the given action until it is successfully added to the filter's list.