### PR TITLE
route/link: expose IFLA_INFO_SLAVE_KIND

### DIFF
--- a/include/netlink-private/types.h
+++ b/include/netlink-private/types.h
@@ -215,6 +215,7 @@ struct rtnl_link
 	uint8_t				l_linkmode;
 	/* 2 byte hole */
 	char *				l_info_kind;
+	char *				l_info_slave_kind;
 	struct rtnl_link_info_ops *	l_info_ops;
 	void *				l_af_data[AF_MAX];
 	void *				l_info;

--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -223,6 +223,9 @@ extern int	rtnl_link_set_stat(struct rtnl_link *, rtnl_link_stat_id_t,
 extern int	rtnl_link_set_type(struct rtnl_link *, const char *);
 extern char *	rtnl_link_get_type(struct rtnl_link *);
 
+extern int		rtnl_link_set_slave_type(struct rtnl_link *, const char *);
+extern const char *	rtnl_link_get_slave_type(const struct rtnl_link *);
+
 extern void	rtnl_link_set_promiscuity(struct rtnl_link *, uint32_t);
 extern uint32_t	rtnl_link_get_promiscuity(struct rtnl_link *);
 

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1087,7 +1087,9 @@ global:
 	rtnl_link_geneve_set_udp_csum;
 	rtnl_link_geneve_set_udp_zero_csum6_rx;
 	rtnl_link_geneve_set_udp_zero_csum6_tx;
+	rtnl_link_get_slave_type;
 	rtnl_link_is_geneve;
+	rtnl_link_set_slave_type;
 	rtnl_mall_append_action;
 	rtnl_mall_del_action;
 	rtnl_mall_get_classid;


### PR DESCRIPTION
add rtnl_link_{get,set}_slave_type functions to expose the
IFLA_INFO_SLAVE_KIND attribute.