### PR TITLE
Add 64bit rate/ceil support for htb class

### DIFF
--- a/doc/route.txt
+++ b/doc/route.txt
@@ -1843,8 +1843,8 @@ or erqual than the rate of its children.
 +
 [source,c]
 -----
-uint32_t rtnl_htb_get_rate(struct rtnl_class *class);
-int rtnl_htb_set_rate(struct rtnl_class *class, uint32_t ceil);
+uint64_t rtnl_htb_get_rate(struct rtnl_class *class);
+int rtnl_htb_set_rate(struct rtnl_class *class, uint64_t ceil);
 -----
 
 Ceil Rate::
@@ -1856,8 +1856,8 @@ be greater or erqual than the ceil rate of its children.
 +
 [source,c]
 -----
-uint32_t rtnl_htb_get_ceil(struct rtnl_class *class);
-int rtnl_htb_set_ceil(struct rtnl_class *class, uint32_t ceil);
+uint64_t rtnl_htb_get_ceil(struct rtnl_class *class);
+int rtnl_htb_set_ceil(struct rtnl_class *class, uint64_t ceil);
 -----
 
 Burst::

--- a/include/netlink-private/types.h
+++ b/include/netlink-private/types.h
@@ -775,6 +775,8 @@ struct rtnl_htb_class
 	uint32_t		ch_quantum;
 	uint32_t		ch_mask;
 	uint32_t		ch_level;
+	uint64_t		ch_rate64;
+	uint64_t		ch_ceil64;
 };
 
 struct rtnl_cbq

--- a/include/netlink/route/qdisc/htb.h
+++ b/include/netlink/route/qdisc/htb.h
@@ -30,10 +30,10 @@ extern int	rtnl_htb_set_defcls(struct rtnl_qdisc *, uint32_t);
 
 extern uint32_t	rtnl_htb_get_prio(struct rtnl_class *);
 extern int	rtnl_htb_set_prio(struct rtnl_class *, uint32_t);
-extern uint32_t	rtnl_htb_get_rate(struct rtnl_class *);
-extern int	rtnl_htb_set_rate(struct rtnl_class *, uint32_t);
-extern uint32_t	rtnl_htb_get_ceil(struct rtnl_class *);
-extern int	rtnl_htb_set_ceil(struct rtnl_class *, uint32_t);
+extern uint64_t	rtnl_htb_get_rate(struct rtnl_class *);
+extern int	rtnl_htb_set_rate(struct rtnl_class *, uint64_t);
+extern uint64_t	rtnl_htb_get_ceil(struct rtnl_class *);
+extern int	rtnl_htb_set_ceil(struct rtnl_class *, uint64_t);
 extern uint32_t	rtnl_htb_get_rbuffer(struct rtnl_class *);
 extern int	rtnl_htb_set_rbuffer(struct rtnl_class *, uint32_t);
 extern uint32_t	rtnl_htb_get_cbuffer(struct rtnl_class *);

--- a/include/netlink/route/tc.h
+++ b/include/netlink/route/tc.h
@@ -100,8 +100,8 @@ extern uint64_t		rtnl_tc_get_stat(struct rtnl_tc *, enum rtnl_tc_stat);
 extern char *		rtnl_tc_stat2str(enum rtnl_tc_stat, char *, size_t);
 extern int		rtnl_tc_str2stat(const char *);
 
-extern int		rtnl_tc_calc_txtime(int, int);
-extern int		rtnl_tc_calc_bufsize(int, int);
+extern int		rtnl_tc_calc_txtime(int, uint64_t);
+extern int		rtnl_tc_calc_bufsize(int, uint64_t);
 extern int		rtnl_tc_calc_cell_log(int);
 
 extern int		rtnl_tc_read_classid_file(void);

--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -638,7 +638,7 @@ int rtnl_tc_str2stat(const char *name)
  * 
  * @return Required transmit time in micro seconds.
  */
-int rtnl_tc_calc_txtime(int bufsize, int rate)
+int rtnl_tc_calc_txtime(int bufsize, uint64_t rate)
 {
 	double tx_time_secs;
 	
@@ -661,7 +661,7 @@ int rtnl_tc_calc_txtime(int bufsize, int rate)
  *
  * @return Size of buffer in bytes.
  */
-int rtnl_tc_calc_bufsize(int txtime, int rate)
+int rtnl_tc_calc_bufsize(int txtime, uint64_t rate)
 {
 	double bufsize;
 

--- a/python/netlink/route/capi.i
+++ b/python/netlink/route/capi.i
@@ -417,10 +417,10 @@ extern int	rtnl_htb_set_defcls(struct rtnl_qdisc *, uint32_t);
 
 extern uint32_t	rtnl_htb_get_prio(struct rtnl_class *);
 extern int	rtnl_htb_set_prio(struct rtnl_class *, uint32_t);
-extern uint32_t	rtnl_htb_get_rate(struct rtnl_class *);
-extern int	rtnl_htb_set_rate(struct rtnl_class *, uint32_t);
-extern uint32_t	rtnl_htb_get_ceil(struct rtnl_class *);
-extern int	rtnl_htb_set_ceil(struct rtnl_class *, uint32_t);
+extern uint64_t	rtnl_htb_get_rate(struct rtnl_class *);
+extern int	rtnl_htb_set_rate(struct rtnl_class *, uint64_t);
+extern uint64_t	rtnl_htb_get_ceil(struct rtnl_class *);
+extern int	rtnl_htb_set_ceil(struct rtnl_class *, uint64_t);
 extern uint32_t	rtnl_htb_get_rbuffer(struct rtnl_class *);
 extern int	rtnl_htb_set_rbuffer(struct rtnl_class *, uint32_t);
 extern uint32_t	rtnl_htb_get_cbuffer(struct rtnl_class *);


### PR DESCRIPTION
Htb class has already supported 64bit rate and ceil settings for times.
Now, in this patch, we grant this ability to libnl library.