### PR TITLE
Add SPDX identifiers

### DIFF
--- a/lib/addr.c
+++ b/lib/addr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/addr.c		Network Address
  *

--- a/lib/attr.c
+++ b/lib/attr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/attr.c		Netlink Attributes
  *

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/cache.c		Caching Module
  *

--- a/lib/cache_mngr.c
+++ b/lib/cache_mngr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/cache_mngr.c	Cache Manager
  *

--- a/lib/cache_mngt.c
+++ b/lib/cache_mngt.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/cache_mngt.c	Cache Management
  *

--- a/lib/data.c
+++ b/lib/data.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/data.c		Abstract Data
  *

--- a/lib/error.c
+++ b/lib/error.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/error.c		Error Handling
  *

--- a/lib/fib_lookup/lookup.c
+++ b/lib/fib_lookup/lookup.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/fib_lookup/lookup.c	FIB Lookup
  *

--- a/lib/fib_lookup/request.c
+++ b/lib/fib_lookup/request.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/fib_lookup/request.c	FIB Lookup Request
  *

--- a/lib/genl/ctrl.c
+++ b/lib/genl/ctrl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/genl/ctrl.c		Generic Netlink Controller
  *

--- a/lib/genl/family.c
+++ b/lib/genl/family.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/genl/family.c		Generic Netlink Family
  *

--- a/lib/genl/genl.c
+++ b/lib/genl/genl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/genl/genl.c		Generic Netlink
  *

--- a/lib/genl/mngt.c
+++ b/lib/genl/mngt.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/genl/mngt.c		Generic Netlink Management
  *

--- a/lib/handlers.c
+++ b/lib/handlers.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/handlers.c	default netlink message handlers
  *

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * This code was taken from http://ccodearchive.net/info/hash.html
  * The original file was modified to remove unwanted code

--- a/lib/hashtable.c
+++ b/lib/hashtable.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * netlink/hashtable.c      Netlink hashtable Utilities
  *

--- a/lib/idiag/idiag.c
+++ b/lib/idiag/idiag.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  *  lib/idiag/idiag.c    Inet Diag Netlink
  *

--- a/lib/idiag/idiag_meminfo_obj.c
+++ b/lib/idiag/idiag_meminfo_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/idiag/idiagnl_meminfo_obj.c Inet Diag Meminfo Object
  *

--- a/lib/idiag/idiag_msg_obj.c
+++ b/lib/idiag/idiag_msg_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/idiag/idiagnl_msg_obj.c Inet Diag Message Object
  *

--- a/lib/idiag/idiag_req_obj.c
+++ b/lib/idiag/idiag_req_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/idiag/idiagnl_req_obj.c Inet Diag Request Object
  *

--- a/lib/idiag/idiag_vegasinfo_obj.c
+++ b/lib/idiag/idiag_vegasinfo_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/idiag/idiagnl_vegasinfo_obj.c Inet Diag TCP Vegas Info Object
  *

--- a/lib/mpls.c
+++ b/lib/mpls.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Adapted from mpls_ntop and mpls_pton copied from iproute2,
  * lib/mpls_ntop.c and lib/mpls_pton.c

--- a/lib/msg.c
+++ b/lib/msg.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/msg.c		Netlink Messages Interface
  *

--- a/lib/netfilter/ct.c
+++ b/lib/netfilter/ct.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/ct.c	Conntrack
  *

--- a/lib/netfilter/ct_obj.c
+++ b/lib/netfilter/ct_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/ct_obj.c	Conntrack Object
  *

--- a/lib/netfilter/exp.c
+++ b/lib/netfilter/exp.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/exp.c	Conntrack Expectation
  *

--- a/lib/netfilter/exp_obj.c
+++ b/lib/netfilter/exp_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/exp_obj.c	Conntrack Expectation Object
  *

--- a/lib/netfilter/log.c
+++ b/lib/netfilter/log.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/log.c	Netfilter Log
  *

--- a/lib/netfilter/log_msg.c
+++ b/lib/netfilter/log_msg.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/log_msg.c	Netfilter Log Message
  *

--- a/lib/netfilter/log_msg_obj.c
+++ b/lib/netfilter/log_msg_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/log_msg_obj.c	Netfilter Log Object
  *

--- a/lib/netfilter/log_obj.c
+++ b/lib/netfilter/log_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/log_obj.c	Netfilter Log Object
  *

--- a/lib/netfilter/netfilter.c
+++ b/lib/netfilter/netfilter.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/netfilter.c    Netfilter Generic Functions
  *

--- a/lib/netfilter/nfnl.c
+++ b/lib/netfilter/nfnl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/nfnl.c		Netfilter Netlink
  *

--- a/lib/netfilter/queue.c
+++ b/lib/netfilter/queue.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/queue.c	Netfilter Queue
  *

--- a/lib/netfilter/queue_msg.c
+++ b/lib/netfilter/queue_msg.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/queue_msg.c	Netfilter Queue Messages
  *

--- a/lib/netfilter/queue_msg_obj.c
+++ b/lib/netfilter/queue_msg_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/queue_msg_obj.c	Netfilter Queue Message Object
  *

--- a/lib/netfilter/queue_obj.c
+++ b/lib/netfilter/queue_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/netfilter/queue_obj.c	Netfilter Queue
  *

--- a/lib/nl.c
+++ b/lib/nl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/nl.c		Core Netlink Interface
  *

--- a/lib/object.c
+++ b/lib/object.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/object.c		Generic Cacheable Object
  *

--- a/lib/route/act.c
+++ b/lib/route/act.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/act.c       Action
  *

--- a/lib/route/addr.c
+++ b/lib/route/addr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/addr.c		Addresses
  *

--- a/lib/route/class.c
+++ b/lib/route/class.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/class.c            Traffic Classes
  *

--- a/lib/route/classid.c
+++ b/lib/route/classid.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/classid.c       ClassID Management
  *

--- a/lib/route/cls.c
+++ b/lib/route/cls.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/classifier.c       Classifier
  *

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/link.c	Links (Interfaces)
  *

--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/neigh.c	Neighbours
  *

--- a/lib/route/neightbl.c
+++ b/lib/route/neightbl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/neightbl.c         neighbour tables
  *

--- a/lib/route/netconf.c
+++ b/lib/route/netconf.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/netconf.c		netconf
  *

--- a/lib/route/nexthop.c
+++ b/lib/route/nexthop.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/nexthop.c	Routing Nexthop
  *

--- a/lib/route/nexthop_encap.c
+++ b/lib/route/nexthop_encap.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 
 #include <netlink-private/netlink.h>
 #include <netlink-private/types.h>

--- a/lib/route/nh_encap_mpls.c
+++ b/lib/route/nh_encap_mpls.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 
 #include <netlink-private/netlink.h>
 #include <netlink-private/types.h>

--- a/lib/route/pktloc.c
+++ b/lib/route/pktloc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/pktloc.c     Packet Location Aliasing
  *

--- a/lib/route/qdisc.c
+++ b/lib/route/qdisc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/qdisc.c            Queueing Disciplines
  *

--- a/lib/route/route.c
+++ b/lib/route/route.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/route.c	Routes
  *

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/route_obj.c	Route Object
  *

--- a/lib/route/route_utils.c
+++ b/lib/route/route_utils.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/route_utils.c	Routing Utilities
  *

--- a/lib/route/rtnl.c
+++ b/lib/route/rtnl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/rtnl.c		Routing Netlink
  *

--- a/lib/route/rule.c
+++ b/lib/route/rule.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/rule.c          Routing Rules
  *

--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/route/tc.c		Traffic Control
  *

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/socket.c		Netlink Socket
  *

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/utils.c		Utility Functions
  *

--- a/lib/version.c
+++ b/lib/version.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * lib/version.c	Run-time version information
  *

--- a/lib/xfrm/ae.c
+++ b/lib/xfrm/ae.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *

--- a/lib/xfrm/lifetime.c
+++ b/lib/xfrm/lifetime.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *

--- a/lib/xfrm/selector.c
+++ b/lib/xfrm/selector.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *

--- a/lib/xfrm/sp.c
+++ b/lib/xfrm/sp.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *

--- a/lib/xfrm/template.c
+++ b/lib/xfrm/template.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *

--- a/src/genl-ctrl-list.c
+++ b/src/genl-ctrl-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/genl-ctrl-list.c	List Generic Netlink Families
  *

--- a/src/idiag-socket-details.c
+++ b/src/idiag-socket-details.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/idiag-socket-details.c     List socket details
  *

--- a/src/lib/addr.c
+++ b/src/lib/addr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/addr.c     Address Helpers
  *

--- a/src/lib/class.c
+++ b/src/lib/class.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/class.c     CLI Class Helpers
  *

--- a/src/lib/cls.c
+++ b/src/lib/cls.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/cls.c     	CLI Classifier Helpers
  *

--- a/src/lib/ct.c
+++ b/src/lib/ct.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/ct.c		CLI Conntrack Helpers
  *

--- a/src/lib/exp.c
+++ b/src/lib/exp.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/exp.c		CLI Expectation Helpers
  *

--- a/src/lib/link.c
+++ b/src/lib/link.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/link.c     CLI Link Helpers
  *

--- a/src/lib/neigh.c
+++ b/src/lib/neigh.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/neigh.c     CLI Neighbour Helpers
  *

--- a/src/lib/qdisc.c
+++ b/src/lib/qdisc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/qdisc.c     CLI QDisc Helpers
  *

--- a/src/lib/route.c
+++ b/src/lib/route.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/route.c     CLI Route Helpers
  *

--- a/src/lib/rule.c
+++ b/src/lib/rule.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/rule.c     CLI Routing Rule Helpers
  *

--- a/src/lib/tc.c
+++ b/src/lib/tc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/lib/tc.c     CLI Traffic Control Helpers
  *

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/utils.c		Utilities
  *

--- a/src/nf-ct-add.c
+++ b/src/nf-ct-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-ct-add.c     Add Conntrack Entry
  *

--- a/src/nf-ct-events.c
+++ b/src/nf-ct-events.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-ct-events.c	  Listen on Conntrack Events
  *

--- a/src/nf-ct-list.c
+++ b/src/nf-ct-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-ct-list.c     List Conntrack Entries
  *

--- a/src/nf-exp-add.c
+++ b/src/nf-exp-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-exp-add.c     Create an expectation
  *

--- a/src/nf-exp-delete.c
+++ b/src/nf-exp-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-exp-delete.c     Delete an expectation
  *

--- a/src/nf-exp-list.c
+++ b/src/nf-exp-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-exp-list.c     List Expectation Entries
  *

--- a/src/nf-log.c
+++ b/src/nf-log.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-log.c     Monitor netfilter log events
  *

--- a/src/nf-monitor.c
+++ b/src/nf-monitor.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-monitor.c     Monitor netfilter events
  *

--- a/src/nf-queue.c
+++ b/src/nf-queue.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nf-queue.c     Monitor netfilter queue events
  *

--- a/src/nl-addr-add.c
+++ b/src/nl-addr-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-addr-add.c     Add addresses
  *

--- a/src/nl-addr-delete.c
+++ b/src/nl-addr-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-addr-delete.c     Delete addresses
  *

--- a/src/nl-addr-list.c
+++ b/src/nl-addr-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-addr-list.c     List addresses
  *

--- a/src/nl-class-add.c
+++ b/src/nl-class-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-class-add.c     Add/Update/Replace Traffic Class
  *

--- a/src/nl-class-delete.c
+++ b/src/nl-class-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-class-delete.c     Delete Traffic Classes
  *

--- a/src/nl-class-list.c
+++ b/src/nl-class-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-class-list.c     List Traffic Classes
  *

--- a/src/nl-classid-lookup.c
+++ b/src/nl-classid-lookup.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-classid-lookup.c     Lookup classid
  *

--- a/src/nl-cls-add.c
+++ b/src/nl-cls-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-cls-add.c     Add classifier
  *

--- a/src/nl-cls-delete.c
+++ b/src/nl-cls-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-cls-delete.c     Delete Classifier
  *

--- a/src/nl-cls-list.c
+++ b/src/nl-cls-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-cls-list.c     	List classifiers
  *

--- a/src/nl-fib-lookup.c
+++ b/src/nl-fib-lookup.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-fib-lookup.c		FIB Route Lookup
  *

--- a/src/nl-link-enslave.c
+++ b/src/nl-link-enslave.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-enslave.c     Enslave a link
  *

--- a/src/nl-link-ifindex2name.c
+++ b/src/nl-link-ifindex2name.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-ifindex2name.c     Transform a interface index to its name
  *

--- a/src/nl-link-list.c
+++ b/src/nl-link-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-dump.c	Dump link attributes
  *

--- a/src/nl-link-name2ifindex.c
+++ b/src/nl-link-name2ifindex.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-name2ifindex.c     Transform a interface name to its index
  *

--- a/src/nl-link-release.c
+++ b/src/nl-link-release.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-release.c     release a link
  *

--- a/src/nl-link-set.c
+++ b/src/nl-link-set.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-set.c     Set link attributes
  *

--- a/src/nl-link-stats.c
+++ b/src/nl-link-stats.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-link-stats.c     Retrieve link statistics
  *

--- a/src/nl-list-caches.c
+++ b/src/nl-list-caches.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * nl-list-caches.c	List registered cache types
  *

--- a/src/nl-list-sockets.c
+++ b/src/nl-list-sockets.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * nl-list-sockets.c	Pretty-print /proc/net/netlink
  *

--- a/src/nl-monitor.c
+++ b/src/nl-monitor.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-monitor.c     Monitor events
  *

--- a/src/nl-neigh-add.c
+++ b/src/nl-neigh-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/ nl-neigh-add.c     Add a neighbour
  *

--- a/src/nl-neigh-delete.c
+++ b/src/nl-neigh-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-neigh-delete.c     Delete a neighbour
  *

--- a/src/nl-neigh-list.c
+++ b/src/nl-neigh-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-neigh-list.c      List Neighbours
  *

--- a/src/nl-neightbl-list.c
+++ b/src/nl-neightbl-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-neightbl-list.c     Dump neighbour tables
  *

--- a/src/nl-pktloc-lookup.c
+++ b/src/nl-pktloc-lookup.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-pktloc-lookup.c     Lookup packet location alias
  *

--- a/src/nl-qdisc-add.c
+++ b/src/nl-qdisc-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-qdisc-add.c     Add Queueing Discipline
  *

--- a/src/nl-qdisc-delete.c
+++ b/src/nl-qdisc-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-qdisc-delete.c     Delete Queuing Disciplines
  *

--- a/src/nl-qdisc-list.c
+++ b/src/nl-qdisc-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-qdisc-list.c     List Queueing Disciplines
  *

--- a/src/nl-route-add.c
+++ b/src/nl-route-add.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-route-add.c     Route addition utility
  *

--- a/src/nl-route-delete.c
+++ b/src/nl-route-delete.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-route-delete.c     Delete Routes
  *

--- a/src/nl-route-get.c
+++ b/src/nl-route-get.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-route-get.c     Get Route Attributes
  *

--- a/src/nl-route-list.c
+++ b/src/nl-route-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-route-list.c     List route attributes
  *

--- a/src/nl-rule-list.c
+++ b/src/nl-rule-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-rule-dump.c     Dump rule attributes
  *

--- a/src/nl-tctree-list.c
+++ b/src/nl-tctree-list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-tctree-list.c		List Traffic Control Tree
  *

--- a/src/nl-util-addr.c
+++ b/src/nl-util-addr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * src/nl-util-addr.c     Address Helper
  *


### PR DESCRIPTION
Software Package Data Exchange identifiers help to detect source file
licenses and hence simplify the FOSS compliance process.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>