### PR TITLE
[th/add-utils-and-various-cleanup]

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -8,6 +8,8 @@ if [ "$CC" = "clang" ]; then
 	CFLAGS="$CFLAGS -Wno-error=unused-command-line-argument -Wno-error=unused-function"
 fi
 
+CFLAGS="$CFLAGS -DNL_MORE_ASSERTS=1000"
+
 export CFLAGS
 ./autogen.sh
 ./configure

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CFLAGS="-Werror -Wall -Wdeclaration-after-statement"
+CFLAGS="-Werror -Wall -Wdeclaration-after-statement -Wvla"
 
 if [ "$CC" = "clang" ]; then
 	CFLAGS="$CFLAGS -Wno-error=unused-command-line-argument -Wno-error=unused-function"

--- a/include/netlink-private/utils.h
+++ b/include/netlink-private/utils.h
@@ -13,6 +13,7 @@
 #define NETLINK_UTILS_PRIV_H_
 
 #include <byteswap.h>
+
 #if __BYTE_ORDER == __BIG_ENDIAN
 #define ntohll(x) (x)
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
@@ -20,11 +21,203 @@
 #endif
 #define htonll(x) ntohll(x)
 
-extern const char *	nl_strerror_l(int err);
+/*****************************************************************************/
+
+#define _NL_STRINGIFY_ARG(contents)       #contents
+#define _NL_STRINGIFY(macro_or_string)    _NL_STRINGIFY_ARG (macro_or_string)
+
+/*****************************************************************************/
+
+#if defined (__GNUC__)
+#define _NL_PRAGMA_WARNING_DO(warning)       _NL_STRINGIFY(GCC diagnostic ignored warning)
+#elif defined (__clang__)
+#define _NL_PRAGMA_WARNING_DO(warning)       _NL_STRINGIFY(clang diagnostic ignored warning)
+#endif
+
+/* you can only suppress a specific warning that the compiler
+ * understands. Otherwise you will get another compiler warning
+ * about invalid pragma option.
+ * It's not that bad however, because gcc and clang often have the
+ * same name for the same warning. */
+
+#if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#define _NL_PRAGMA_WARNING_DISABLE(warning) \
+        _Pragma("GCC diagnostic push") \
+        _Pragma(_NL_PRAGMA_WARNING_DO("-Wpragmas")) \
+        _Pragma(_NL_PRAGMA_WARNING_DO(warning))
+#elif defined (__clang__)
+#define _NL_PRAGMA_WARNING_DISABLE(warning) \
+        _Pragma("clang diagnostic push") \
+        _Pragma(_NL_PRAGMA_WARNING_DO("-Wunknown-warning-option")) \
+        _Pragma(_NL_PRAGMA_WARNING_DO(warning))
+#else
+#define _NL_PRAGMA_WARNING_DISABLE(warning)
+#endif
+
+#if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#define _NL_PRAGMA_WARNING_REENABLE \
+    _Pragma("GCC diagnostic pop")
+#elif defined (__clang__)
+#define _NL_PRAGMA_WARNING_REENABLE \
+    _Pragma("clang diagnostic pop")
+#else
+#define _NL_PRAGMA_WARNING_REENABLE
+#endif
+
+/*****************************************************************************/
+
+#define _nl_unused                  __attribute__ ((__unused__))
+#define _nl_auto(fcn)               __attribute__ ((__cleanup__(fcn)))
+
+/*****************************************************************************/
+
+#define _NL_STATIC_ASSERT(cond) ((void) sizeof (char[(cond) ? 1 : -1]))
+
+/*****************************************************************************/
+
+#if defined(NL_MORE_ASSERTS) && NL_MORE_ASSERTS > 0
+#define _nl_assert(cond) assert(cond)
+#else
+#define _nl_assert(cond) do { if (0) { assert(cond); } } while (0)
+#endif
+
+/*****************************************************************************/
+
+#define _NL_AUTO_DEFINE_FCN_VOID0(CastType, name, func) \
+static inline void name (void *v) \
+{ \
+	if (*((CastType *) v)) \
+		func (*((CastType *) v)); \
+}
+
+#define _nl_auto_free _nl_auto(_nl_auto_free_fcn)
+_NL_AUTO_DEFINE_FCN_VOID0 (void *, _nl_auto_free_fcn, free)
+
+/*****************************************************************************/
+
+extern const char *nl_strerror_l(int err);
+
+/*****************************************************************************/
 
 /* internal macro to calculate the size of a struct @type up to (and including) @field.
  * this will be used for .minlen policy fields, so that we require only a field of up
  * to the given size. */
 #define _nl_offsetofend(type, field) (offsetof (type, field) + sizeof (((type *) NULL)->field))
+
+/*****************************************************************************/
+
+#define _nl_clear_pointer(pp, destroy) \
+	({ \
+		typeof (*(pp)) *_pp = (pp); \
+		typeof (*_pp) _p; \
+		int _changed = 0; \
+		\
+		if (   _pp \
+			&& (_p = *_pp)) { \
+			_nl_unused const void *const _p_check_is_pointer = _p; \
+			\
+			*_pp = NULL; \
+			\
+			(destroy) (_p); \
+			\
+			_changed = 1; \
+		} \
+		_changed; \
+	})
+
+#define _nl_clear_free(pp) _nl_clear_pointer (pp, free)
+
+#define _nl_steal_pointer(pp) \
+	({ \
+		typeof (*(pp)) *const _pp = (pp); \
+		typeof (*_pp) _p = NULL; \
+		\
+		if (   _pp \
+		    && (_p = *_pp)) { \
+			*_pp = NULL; \
+		} \
+		\
+		_p; \
+	})
+
+/*****************************************************************************/
+
+#define _nl_malloc_maybe_a(alloca_maxlen, bytes, to_free) \
+	({ \
+		const size_t _bytes = (bytes); \
+		typeof (to_free) _to_free = (to_free); \
+		typeof (*_to_free) _ptr; \
+		\
+		_NL_STATIC_ASSERT ((alloca_maxlen) <= 500); \
+		_nl_assert (_to_free && !*_to_free); \
+		\
+		if (_bytes <= (alloca_maxlen)) { \
+			_ptr = alloca (_bytes); \
+		} else { \
+			_ptr = malloc (_bytes); \
+			*_to_free = _ptr; \
+		}; \
+		\
+		_ptr; \
+	})
+
+/*****************************************************************************/
+
+static inline char *
+_nl_strncpy_trunc(char *dst, const char *src, size_t len)
+{
+	/* we don't use/reimplement strlcpy(), because we want the fill-all-with-NUL
+	 * behavior of strncpy(). This is just strncpy() with gracefully handling trunction
+	 * (and disabling the "-Wstringop-truncation" warning).
+	 *
+	 * Note that truncation is silently accepted.
+	 */
+
+	_NL_PRAGMA_WARNING_DISABLE ("-Wstringop-truncation");
+	_NL_PRAGMA_WARNING_DISABLE ("-Wstringop-overflow");
+
+	if (len > 0) {
+		_nl_assert(dst);
+		_nl_assert(src);
+
+		strncpy(dst, src, len);
+
+		dst[len - 1] = '\0';
+	}
+
+	_NL_PRAGMA_WARNING_REENABLE;
+	_NL_PRAGMA_WARNING_REENABLE;
+
+	return dst;
+}
+
+static inline char *
+_nl_strncpy(char *dst, const char *src, size_t len)
+{
+	/* we don't use/reimplement strlcpy(), because we want the fill-all-with-NUL
+	 * behavior of strncpy(). This is just strncpy() with gracefully handling trunction
+	 * (and disabling the "-Wstringop-truncation" warning).
+	 *
+	 * Note that truncation is still a bug and there is an _nl_assert()
+	 * against that.
+	 */
+
+	if (len > 0) {
+		_nl_assert(dst);
+		_nl_assert(src);
+
+		strncpy(dst, src, len);
+
+		/* Truncation is a bug and we assert against it. But note that this
+		 * assertion is disabled by default because we cannot be sure that
+		 * there are not wrong uses of _nl_strncpy() where truncation might
+		 * happen (wrongly!!). */
+		_nl_assert (memchr(dst, '\0', len));
+
+		dst[len - 1] = '\0';
+	}
+
+	return dst;
+}
 
 #endif

--- a/lib/genl/family.c
+++ b/lib/genl/family.c
@@ -24,6 +24,8 @@
 #include <netlink/genl/family.h>
 #include <netlink/utils.h>
 
+#include "netlink-private/utils.h"
+
 /** @cond SKIP */
 #define FAMILY_ATTR_ID		0x01
 #define FAMILY_ATTR_NAME	0x02
@@ -364,16 +366,20 @@ int genl_family_add_op(struct genl_family *family, int id, int flags)
 }
 
 int genl_family_add_grp(struct genl_family *family, uint32_t id,
-	       		const char *name)
+                        const char *name)
 {
-	struct genl_family_grp *grp;  
+	struct genl_family_grp *grp;
+
+	if (   !name
+	    || strlen (name) >= GENL_NAMSIZ)
+		return -NLE_INVAL;
 
 	grp = calloc(1, sizeof(*grp));
 	if (grp == NULL)
 		return -NLE_NOMEM;
 
 	grp->id = id;
-	strncpy(grp->name, name, GENL_NAMSIZ - 1);
+	_nl_strncpy(grp->name, name, GENL_NAMSIZ);
 
 	nl_list_add_tail(&grp->list, &family->gf_mc_grps);
 

--- a/lib/genl/mngt.c
+++ b/lib/genl/mngt.c
@@ -26,6 +26,8 @@
 #include <netlink/genl/ctrl.h>
 #include <netlink/utils.h>
 
+#include "netlink-private/utils.h"
+
 /** @cond SKIP */
 
 static NL_LIST_HEAD(genl_ops_list);
@@ -45,41 +47,45 @@ static struct genl_cmd *lookup_cmd(struct genl_ops *ops, int cmd_id)
 }
 
 static int cmd_msg_parser(struct sockaddr_nl *who, struct nlmsghdr *nlh,
-			  struct genl_ops *ops, struct nl_cache_ops *cache_ops, void *arg)
+                          struct genl_ops *ops, struct nl_cache_ops *cache_ops, void *arg)
 {
+	_nl_auto_free struct nlattr **tb_free = NULL;
 	int err;
 	struct genlmsghdr *ghdr;
 	struct genl_cmd *cmd;
+	struct nlattr **tb;
 
 	ghdr = genlmsg_hdr(nlh);
 
-	if (!(cmd = lookup_cmd(ops, ghdr->cmd))) {
-		err = -NLE_MSGTYPE_NOSUPPORT;
-		goto errout;
-	}
+	if (!(cmd = lookup_cmd(ops, ghdr->cmd)))
+		return -NLE_MSGTYPE_NOSUPPORT;
 
 	if (cmd->c_msg_parser == NULL)
-		err = -NLE_OPNOTSUPP;
-	else {
-		struct nlattr *tb[cmd->c_maxattr + 1];
+		return -NLE_OPNOTSUPP;
+
+	tb = _nl_malloc_maybe_a (300, ((size_t) cmd->c_maxattr) + 1, &tb_free);
+	if (!tb)
+		return -NLE_NOMEM;
+
+	err = nlmsg_parse(nlh,
+	                  GENL_HDRSIZE(ops->o_hdrsize),
+	                  tb,
+	                  cmd->c_maxattr,
+	                  cmd->c_attr_policy);
+	if (err < 0)
+		return err;
+
+	{
 		struct genl_info info = {
-			.who = who,
-			.nlh = nlh,
+			.who     = who,
+			.nlh     = nlh,
 			.genlhdr = ghdr,
 			.userhdr = genlmsg_user_hdr(ghdr),
-			.attrs = tb,
+			.attrs   = tb,
 		};
 
-		err = nlmsg_parse(nlh, GENL_HDRSIZE(ops->o_hdrsize), tb, cmd->c_maxattr,
-				  cmd->c_attr_policy);
-		if (err < 0)
-			goto errout;
-
-		err = cmd->c_msg_parser(cache_ops, cmd, &info, arg);
+		return cmd->c_msg_parser(cache_ops, cmd, &info, arg);
 	}
-errout:
-	return err;
-
 }
 
 static int genl_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,

--- a/lib/route/link/inet6.c
+++ b/lib/route/link/inet6.c
@@ -16,6 +16,8 @@
 #include <netlink/route/link/inet6.h>
 #include <netlink-private/route/link/api.h>
 
+#include "netlink-private/utils.h"
+
 #define I6_ADDR_GEN_MODE_UNKNOWN	UINT8_MAX
 
 struct inet6_data
@@ -320,36 +322,36 @@ static void inet6_dump_details(struct rtnl_link *link,
 {
 	struct inet6_data *i6 = data;
 	struct nl_addr *addr;
-	char buf[64], buf2[64];
 	int i, n = 0;
+	char buf[64];
 
 	nl_dump_line(p, "    ipv6 max-reasm-len %s",
-		nl_size2str(i6->i6_cacheinfo.max_reasm_len, buf, sizeof(buf)));
+	             nl_size2str(i6->i6_cacheinfo.max_reasm_len, buf, sizeof(buf)));
 
 	nl_dump(p, " <%s>\n",
-		rtnl_link_inet6_flags2str(i6->i6_flags, buf, sizeof(buf)));
-
+	        rtnl_link_inet6_flags2str(i6->i6_flags, buf, sizeof(buf)));
 
 	nl_dump_line(p, "      create-stamp %.2fs reachable-time %s",
-		(double) i6->i6_cacheinfo.tstamp / 100.,
-		nl_msec2str(i6->i6_cacheinfo.reachable_time, buf, sizeof(buf)));
+	             (double) i6->i6_cacheinfo.tstamp / 100.,
+	             nl_msec2str(i6->i6_cacheinfo.reachable_time, buf, sizeof(buf)));
 
 	nl_dump(p, " retrans-time %s\n",
-		nl_msec2str(i6->i6_cacheinfo.retrans_time, buf, sizeof(buf)));
+	        nl_msec2str(i6->i6_cacheinfo.retrans_time, buf, sizeof(buf)));
 
 	addr = nl_addr_build(AF_INET6, &i6->i6_token, sizeof(i6->i6_token));
 	nl_dump(p, "      token %s\n",
-		nl_addr2str(addr, buf, sizeof(buf)));
+	        nl_addr2str(addr, buf, sizeof(buf)));
 	nl_addr_put(addr);
 
 	nl_dump(p, "      link-local address mode %s\n",
-		rtnl_link_inet6_addrgenmode2str(i6->i6_addr_gen_mode,
-						buf, sizeof(buf)));
+	        rtnl_link_inet6_addrgenmode2str(i6->i6_addr_gen_mode,
+	                                        buf, sizeof(buf)));
 
 	nl_dump_line(p, "      devconf:\n");
 	nl_dump_line(p, "      ");
 
 	for (i = 0; i < DEVCONF_MAX; i++) {
+		char buf2[64];
 		uint32_t value = i6->i6_conf[i];
 		int x, offset;
 
@@ -368,7 +370,6 @@ static void inet6_dump_details(struct rtnl_link *link,
 		default:
 			snprintf(buf2, sizeof(buf2), "%u", value);
 			break;
-			
 		}
 
 		inet6_devconf2str(i, buf, sizeof(buf));
@@ -380,7 +381,7 @@ static void inet6_dump_details(struct rtnl_link *link,
 		for (x = strlen(buf); x < offset; x++)
 			buf[x] = ' ';
 
-		strncpy(&buf[offset], buf2, strlen(buf2));
+		_nl_strncpy_trunc(&buf[offset], buf2, sizeof(buf) - offset);
 
 		nl_dump_line(p, "%s", buf);
 

--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -24,6 +24,8 @@
 #include <netlink/route/tc.h>
 #include <netlink-private/route/tc-api.h>
 
+#include "netlink-private/utils.h"
+
 /** @cond SKIP */
 
 static struct nl_list_head tc_ops_list[__RTNL_TC_TYPE_MAX];
@@ -529,7 +531,12 @@ int rtnl_tc_set_kind(struct rtnl_tc *tc, const char *kind)
 	if (tc->ce_mask & TCA_ATTR_KIND)
 		return -NLE_EXIST;
 
-	strncpy(tc->tc_kind, kind, sizeof(tc->tc_kind) - 1);
+	if (   !kind
+	    || strlen (kind) >= sizeof (tc->tc_kind))
+		return -NLE_INVAL;
+
+	_nl_strncpy(tc->tc_kind, kind, sizeof(tc->tc_kind));
+
 	tc->ce_mask |= TCA_ATTR_KIND;
 
 	/* Force allocation of data */


### PR DESCRIPTION
I think we need some convenience macros and helper to make implementing libnl more convenient (and less prone to accidental errors). Add `__attribute__((__cleanup__(fcn)))` macros and various other helpers.

Also, don't allow VLAs and fix memory corruption in xfrm-sa setters.