### PR TITLE
build: add Libs.private field in libnl pkg-config file

### DIFF
--- a/libnl-3.0.pc.in
+++ b/libnl-3.0.pc.in
@@ -7,4 +7,5 @@ Name: libnl
 Description: Convenience library for netlink sockets
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lnl-@MAJ_VERSION@
+Libs.private: @LIBS@
 Cflags: -I${includedir}/libnl@MAJ_VERSION@


### PR DESCRIPTION
In order to support static linking, the libnl pkg-config file should
indicate in its Libs.private field the libraries that libnl-3.0.a
requires. The LIBS variable contains the appropriate list of
libraries: -lm in all cases, and -lpthread when pthread support is
enabled. This allows to statically link applications against libnl
properly.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libnl/0001-build-add-Libs.private-field-in-libnl-pkg-config-fil.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>