### PR TITLE
Remove VLAN from mandatory neigh comparison flags

### DIFF
--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -321,10 +321,9 @@ static uint32_t neigh_id_attrs_get(struct nl_object *obj)
 	if (neigh->n_family == AF_BRIDGE) {
 		if (neigh->n_flags & NTF_SELF)
 			return (NEIGH_ATTR_LLADDR | NEIGH_ATTR_FAMILY | NEIGH_ATTR_IFINDEX |
-				       ((neigh->ce_mask & NEIGH_ATTR_DST) ? NEIGH_ATTR_DST: 0) |
-				       ((neigh->ce_mask & NEIGH_ATTR_VLAN) ? NEIGH_ATTR_VLAN : 0));
+				       ((neigh->ce_mask & NEIGH_ATTR_DST) ? NEIGH_ATTR_DST: 0);
 		else
-			return (NEIGH_ATTR_LLADDR | NEIGH_ATTR_FAMILY | NEIGH_ATTR_MASTER | NEIGH_ATTR_VLAN);
+			return (NEIGH_ATTR_LLADDR | NEIGH_ATTR_FAMILY | NEIGH_ATTR_MASTER);
 	} else
 		return neigh_obj_ops.oo_id_attrs;
 }


### PR DESCRIPTION
### Issue
The neighbor cache fails to compare objects for equality and is leaking objects stored in the neighbor hash table. The VLAN attribute is listed as mandatory to enable neighbor object comparison, but it is very often not received from linux at all.

### Testing
I'm running libnl 3.4 with this to fix the leak: [patch_for_libnl_3.4.patch.txt](https://github.com/thom311/libnl/files/4311167/patch_for_libnl_3.4.patch.txt). I've not had a chance to test with 3.5.

I've tried running kernels 4.1 and 4.19, both of them were NOT always sending the VLAN attribute, resulting in a leak, unless this patch was applied.

### Details
Remove NEIGH_ATTR_VLAN from the set of mandatory comparison flags, allowing netlink neighbor cache to release all resources when being cleaned.

Linux kernels without bugfix https://github.com/torvalds/linux/commit/f82ef3e10a870acc19fa04f80ef5877eaa26f41e do not send `NDA_VLAN` for neighbors, and thus objects of `AF_BRIDGE` family never contain the `NEIGH_ATTR_VLAN` attribute. Furthermore, the attribute is not always sent even with the above change (see https://github.com/torvalds/linux/commit/47fab41ab51a18a2e5fc4ec63f16b4c6702809b6).

The attribute is (wrongly) marked as mandatory for object comparison by `nl_object_identical()` which always returns false without it. One of the consequences is hashtable's inability to remove entries during `nl_cache_clear()`. The hashtable does not release such stored objects, which do not get freed and waste memory. Refreshing the neighbor cache amplifies this leak.