### PR TITLE
xfrm: remove superfluous xfrm_usersa_id from dump request

### DIFF
--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -650,11 +650,7 @@ static struct nla_policy xfrm_sa_policy[XFRMA_MAX+1] = {
 
 static int xfrm_sa_request_update(struct nl_cache *c, struct nl_sock *h)
 {
-	struct xfrm_id sa_id;
-
-	memset (&sa_id, 0, sizeof (sa_id));
-	return nl_send_simple (h, XFRM_MSG_GETSA, NLM_F_DUMP,
-	                       &sa_id, sizeof (sa_id));
+	return nl_send_simple (h, XFRM_MSG_GETSA, NLM_F_DUMP, NULL, 0);
 }
 
 int xfrmnl_sa_parse(struct nlmsghdr *n, struct xfrmnl_sa **result)


### PR DESCRIPTION
When being used with the dump flag, the kernel dispatches the request to
xfrm_dump_sa. This function does not expect the netlink message to
contain a struct xfrm_usersa_id as data payload of the netlink message.
Instead it interprets this payload as xfrm attributes. With the current
implementation, due to the sa_id being memset to zero, it causes the
kernel to complain about '24 bytes leftover after parsing attributes
[...]'.
This patch removes payload to get rid of the kernel complaint.

Signed-off-by: Thomas Egerer <thomas.egerer@secunet.com>