### PR TITLE
Fix missing RX packets stat

### DIFF
--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -99,6 +99,7 @@ typedef enum {
 	RTNL_LINK_IP6_ECT0PKTS,		/*!< IPv6 SNMP InECT0Pkts */
 	RTNL_LINK_IP6_CEPKTS,		/*!< IPv6 SNMP InCEPkts */
 	RTNL_LINK_RX_NOHANDLER,		/*!< Received packets dropped on inactive device */
+	RTNL_LINK_REASM_OVERLAPS,       /*!< SNMP ReasmOverlaps */
 	__RTNL_LINK_STATS_MAX,
 } rtnl_link_stat_id_t;
 

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -3063,6 +3063,7 @@ static const struct trans_tbl link_stats[] = {
 	__ADD(RTNL_LINK_IP6_ECT0PKTS, Ip6_InECT0Pkts),
 	__ADD(RTNL_LINK_IP6_CEPKTS, Ip6_InCEPkts),
 	__ADD(RTNL_LINK_RX_NOHANDLER, rx_nohandler),
+	__ADD(RTNL_LINK_REASM_OVERLAPS, ReasmOverlaps),
 };
 
 char *rtnl_link_stat2str(int st, char *buf, size_t len)

--- a/lib/route/link/inet6.c
+++ b/lib/route/link/inet6.c
@@ -141,6 +141,7 @@ static const uint8_t map_stat_id_from_IPSTATS_MIB_v2[__IPSTATS_MIB_MAX] = {
 	[33] = RTNL_LINK_IP6_ECT1PKTS,                  /* IPSTATS_MIB_ECT1PKTS                 */
 	[34] = RTNL_LINK_IP6_ECT0PKTS,                  /* IPSTATS_MIB_ECT0PKTS                 */
 	[35] = RTNL_LINK_IP6_CEPKTS,                    /* IPSTATS_MIB_CEPKTS                   */
+	[36] = RTNL_LINK_REASM_OVERLAPS,                /* IPSTATS_MIB_REASM_OVERLAPS           */
 };
 
 static int inet6_parse_protinfo(struct rtnl_link *link, struct nlattr *attr,


### PR DESCRIPTION
Version 3.5.0 contains a regression. RX packets link stat reports values different from `/sys/class/net/$link/statistics/rx_packets`. In my tests it is always 0.

Below is a relatively small program that reproduces the issue.
```c
#include <stdio.h>
#include <stdlib.h>
#include <stdarg.h>

#include <netlink/cache.h>
#include <netlink/netlink.h>
#include <netlink/socket.h>
#include <netlink/route/link.h>

#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))

void failf(const char *fmt, ...)
{
	va_list args;
	va_start(args, fmt);
	vfprintf(stderr, fmt, args);
	va_end(args);
	exit(1);
}

int main(int argc, char **argv)
{
	struct nl_sock *sock;
	struct nl_cache *cache;
	struct rtnl_link *link;
	int err;

	char sname[32];
	uint32_t i, j;

	const rtnl_link_stat_id_t stats[] = {
		RTNL_LINK_RX_PACKETS,
		RTNL_LINK_RX_BYTES,
		RTNL_LINK_TX_PACKETS,
		RTNL_LINK_TX_BYTES,
	};

	sock = nl_socket_alloc();
	if (!sock)
		failf("nl_socket_alloc\n");
	if ((err = nl_connect(sock, NETLINK_ROUTE)) != 0)
		failf("nl_connect: %s\n", nl_geterror(err));
	if ((err = rtnl_link_alloc_cache(sock, AF_UNSPEC, &cache)) != 0)
		failf("rtnl_link_alloc_cache: %s\n", nl_geterror(err));

	for (j = 1; j < (uint32_t)argc; j++) {
		link = rtnl_link_get_by_name(cache, argv[j]);
		if (!link)
			failf("link '%s' not found\n", argv[j]);
		printf("%s\n", argv[j]);
		for (i = 0; i < ARRAY_SIZE(stats); i++) {
			rtnl_link_stat2str(stats[i], sname, 32);
			printf("%s\t%lu\n", sname, rtnl_link_get_stat(link, stats[i]));
		}
	}

	return 0;
}
```
```
$ cat /sys/class/net/enp0s3/statistics/[rt]x_packets
218507
116827
$ ./getstats enp0s3
enp0s3
rx_packets	0
rx_bytes	149496428
tx_packets	116828
tx_bytes	16432344
```

The bug was introduced with commit 73c1d047 that added a new enum constant `IPSTATS_MIB_REASM_OVERLAPS`. Right now the constant is missing from `map_stat_id_from_IPSTATS_MIB_v2` and is mapped by it to 0. This tricks `inet6_parse_protinfo()` (called via `ao_parse_af` in `link_msg_parser`) into erroneously overwriting `RTNL_LINK_RX_PACKETS` stat, which happens to have value 0, when it tries to set `IPSTATS_MIB_REASM_OVERLAPS`.

This pull request adds the missing mapping to fix the overwrite. As a side effect, we expose `RTNL_LINK_REASM_OVERLAPS` metric. If that is undesirable, we could map `IPSTATS_MIB_REASM_OVERLAPS` to -1 and ignore in `inet6_parse_protinfo()`.