### PR TITLE
route/netconf: full API export

### DIFF
--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1039,14 +1039,17 @@ global:
 	rtnl_link_inet6_get_flags;
 	rtnl_link_inet6_set_flags;
 	rtnl_link_inet6_str2flags;
+	rtnl_netconf_alloc_cache;
 	rtnl_netconf_get_all;
 	rtnl_netconf_get_by_idx;
 	rtnl_netconf_get_default;
 	rtnl_netconf_get_family;
 	rtnl_netconf_get_forwarding;
 	rtnl_netconf_get_ifindex;
+	rtnl_netconf_get_ignore_routes_linkdown;
 	rtnl_netconf_get_input;
 	rtnl_netconf_get_mc_forwarding;
+	rtnl_netconf_get_proxy_neigh;
 	rtnl_netconf_get_rp_filter;
 	rtnl_netconf_put;
 	rtnl_rule_get_l3mdev;


### PR DESCRIPTION
The following functions have been implemented but not
exported:

rtnl_netconf_alloc_cache()
rtnl_netconf_get_proxy_neigh()
rtnl_netconf_get_ignore_routes_linkdown()

Signed-off-by: Volodymyr Bendiuga <volodymyr.bendiuga@westermo.se>