### PR TITLE
route/link: Check for null pointer in macvlan

### DIFF
--- a/lib/route/link/macvlan.c
+++ b/lib/route/link/macvlan.c
@@ -149,6 +149,8 @@ static void macvlan_free(struct rtnl_link *link)
 	uint32_t i;
 
 	mvi = link->l_info;
+	if (NULL == mvi)
+		return;
 
 	for (i = 0; i < mvi->mvi_maccount; i++)
 		nl_addr_put(mvi->mvi_macaddr[i]);


### PR DESCRIPTION
In cases where link->l_info is not set, a null-ptr-exception
will be invoked.