### PR TITLE
route/cls: allow fetching of classifiers from cache

### DIFF
--- a/include/netlink/route/classifier.h
+++ b/include/netlink/route/classifier.h
@@ -26,6 +26,10 @@ extern void		rtnl_cls_put(struct rtnl_cls *);
 
 extern int		rtnl_cls_alloc_cache(struct nl_sock *, int, uint32_t,
 					     struct nl_cache **);
+extern struct rtnl_cls *rtnl_cls_get(struct nl_cache *cache, int ifindex,
+				     uint32_t parent, uint32_t handle);
+extern struct rtnl_cls *rtnl_cls_get_by_prio(struct nl_cache *cache, int ifindex,
+					     uint32_t parent, uint16_t prio);
 
 extern void 		rtnl_cls_cache_set_tc_params(struct nl_cache *, int, uint32_t);
 

--- a/lib/route/cls.c
+++ b/lib/route/cls.c
@@ -389,8 +389,9 @@ struct rtnl_cls *rtnl_cls_get(struct nl_cache *cache, int ifindex, uint32_t pare
 		return NULL;
 
 	nl_list_for_each_entry(cls, &cache->c_items, ce_list) {
-		if ((cls->c_parent == parent) && (cls->c_ifindex == ifindex)
-		    && (cls->c_handle == handle)) {
+		if ((cls->c_parent == parent) &&
+		    (cls->c_ifindex == ifindex)&&
+		    (cls->c_handle == handle)) {
 			nl_object_get((struct nl_object *) cls);
 			return cls;
 		}
@@ -424,8 +425,9 @@ struct rtnl_cls *rtnl_cls_get_by_prio(struct nl_cache *cache, int ifindex,
 		return NULL;
 
 	nl_list_for_each_entry(cls, &cache->c_items, ce_list) {
-		if ((cls->c_parent == parent) && (cls->c_ifindex == ifindex)
-		    && (cls->c_prio == prio)) {
+		if ((cls->c_parent == parent) &&
+		    (cls->c_ifindex == ifindex) &&
+		    (cls->c_prio == prio)) {
 			nl_object_get((struct nl_object *) cls);
 			return cls;
 		}

--- a/lib/route/cls.c
+++ b/lib/route/cls.c
@@ -364,6 +364,76 @@ void rtnl_cls_cache_set_tc_params(struct nl_cache *cache,
 	cache->c_iarg2 = parent;
 }
 
+/**
+ * Search classifier by interface index, parent and handle
+ * @arg cache           Classifier cache
+ * @arg ifindex         Interface index
+ * @arg parent          Parent
+ * @arg handle          Handle
+ *
+ * Searches a classifier cache previously allocated with rtnl_cls_alloc_cache()
+ * and searches for a classifier matching the interface index, parent
+ * and handle.
+ *
+ * The reference counter is incremented before returning the classifier,
+ * therefore the reference must be given back with rtnl_cls_put() after usage.
+ *
+ * @return Classifier or NULL if no match was found.
+ */
+struct rtnl_cls *rtnl_cls_get(struct nl_cache *cache, int ifindex, uint32_t parent,
+			      uint32_t handle)
+{
+	struct rtnl_cls *cls;
+
+	if (cache->c_ops != &rtnl_cls_ops)
+		return NULL;
+
+	nl_list_for_each_entry(cls, &cache->c_items, ce_list) {
+		if ((cls->c_parent == parent) && (cls->c_ifindex == ifindex)
+		    && (cls->c_handle == handle)) {
+			nl_object_get((struct nl_object *) cls);
+			return cls;
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * Search classifier by interface index, parent and priority
+ * @arg cache           Classifier cache
+ * @arg ifindex         Interface index
+ * @arg parent          Parent
+ * @arg prio            Priority
+ *
+ * Searches a classifier cache previously allocated with rtnl_cls_alloc_cache()
+ * and searches for a classifier matching the interface index, parent
+ * and prio.
+ *
+ * The reference counter is incremented before returning the classifier,
+ * therefore the reference must be given back with rtnl_cls_put() after usage.
+ *
+ * @return Classifier or NULL if no match was found.
+ */
+struct rtnl_cls *rtnl_cls_get_by_prio(struct nl_cache *cache, int ifindex,
+				      uint32_t parent, uint16_t prio)
+{
+	struct rtnl_cls *cls;
+
+	if (cache->c_ops != &rtnl_cls_ops)
+		return NULL;
+
+	nl_list_for_each_entry(cls, &cache->c_items, ce_list) {
+		if ((cls->c_parent == parent) && (cls->c_ifindex == ifindex)
+		    && (cls->c_prio == prio)) {
+			nl_object_get((struct nl_object *) cls);
+			return cls;
+		}
+	}
+
+	return NULL;
+}
+
 /** @} */
 
 static void cls_dump_line(struct rtnl_tc *tc, struct nl_dump_params *p)

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1065,6 +1065,8 @@ libnl_3_5 {
 global:
 	rtnl_class_get_by_parent;
 	rtnl_cls_cache_set_tc_params;
+	rtnl_cls_get;
+	rtnl_cls_get_by_prio;
 	rtnl_ematch_tree_clone;
 	rtnl_htb_get_ceil64;
 	rtnl_htb_get_rate64;

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1065,8 +1065,6 @@ libnl_3_5 {
 global:
 	rtnl_class_get_by_parent;
 	rtnl_cls_cache_set_tc_params;
-	rtnl_cls_get;
-	rtnl_cls_get_by_prio;
 	rtnl_ematch_tree_clone;
 	rtnl_htb_get_ceil64;
 	rtnl_htb_get_rate64;
@@ -1152,3 +1150,9 @@ global:
 	rtnl_vlan_set_vlan_id;
 	rtnl_vlan_set_vlan_prio;
 } libnl_3_4;
+
+libnl_3_6 {
+global:
+	rtnl_cls_get;
+	rtnl_cls_get_by_prio;
+} libnl_3_5;


### PR DESCRIPTION
API:
	rtnl_cls_get()
	rtnl_cls_get_by_prio()

These functions search for classifiers in classifier cache.