### PR TITLE
route/qdisc: allow fetching qdiscs by their kind

### DIFF
--- a/include/netlink/route/qdisc.h
+++ b/include/netlink/route/qdisc.h
@@ -33,6 +33,8 @@ extern struct rtnl_qdisc *
 
 extern struct rtnl_qdisc *
 		rtnl_qdisc_get_by_parent(struct nl_cache *, int, uint32_t);
+extern struct rtnl_qdisc *rtnl_qdisc_get_by_kind(struct nl_cache *cache,
+						  int ifindex, char *kind);
 
 extern int	rtnl_qdisc_build_add_request(struct rtnl_qdisc *, int,
 					     struct nl_msg **);

--- a/lib/route/qdisc.c
+++ b/lib/route/qdisc.c
@@ -404,6 +404,38 @@ struct rtnl_qdisc *rtnl_qdisc_get_by_parent(struct nl_cache *cache,
 }
 
 /**
+ * Search qdisc by kind
+ * @arg cache		Qdisc cache
+ * @arg ifindex		Interface index
+ * @arg kind		Qdisc kind (tbf, htb, cbq, etc)
+ *
+ * Searches a qdisc cache previously allocated with rtnl_qdisc_alloc_cache()
+ * and searches for a qdisc matching the interface index and kind.
+ *
+ * The reference counter is incremented before returning the qdisc, therefore
+ * the reference must be given back with rtnl_qdisc_put() after usage.
+ *
+ * @return pointer to qdisc inside the cache or NULL if no match was found.
+ */
+struct rtnl_qdisc *rtnl_qdisc_get_by_kind(struct nl_cache *cache,
+					    int ifindex, char *kind)
+{
+	struct rtnl_qdisc *q;
+
+	if (cache->c_ops != &rtnl_qdisc_ops)
+		return NULL;
+
+	nl_list_for_each_entry(q, &cache->c_items, ce_list) {
+		if ((q->q_ifindex == ifindex) && (!strcmp(q->q_kind, kind))) {
+			nl_object_get((struct nl_object *) q);
+			return q;
+		}
+	}
+
+	return NULL;
+}
+
+/**
  * Search qdisc by interface index and handle
  * @arg cache		Qdisc cache
  * @arg ifindex		Interface index

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1150,3 +1150,8 @@ global:
 	rtnl_vlan_set_vlan_id;
 	rtnl_vlan_set_vlan_prio;
 } libnl_3_4;
+
+libnl_3_6 {
+global:
+	rtnl_qdisc_get_by_kind;
+} libnl_3_5;


### PR DESCRIPTION
API:
	rtnl_qdisc_get_by_kind()

This function allows getting qdisc based on
its kind, i.e. tbf, htb, cbq, etc.

Signed-off-by: Volodymyr Bendiuga <volodymyr.bendiuga@westermo.se>