### PR TITLE
[th/cleanup-errout]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,6 +261,7 @@ noinst_HEADERS = \
 	include/netlink-private/cache-api.h \
 	include/netlink-private/genl.h \
 	include/netlink-private/netlink.h \
+	include/netlink-private/nl-auto.h \
 	include/netlink-private/object-api.h \
 	include/netlink-private/route/link/api.h \
 	include/netlink-private/route/link/sriov.h \

--- a/include/netlink-private/nl-auto.h
+++ b/include/netlink-private/nl-auto.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LGPL-2.1+
+
+#ifndef NETLINK_NL_AUTO_H_
+#define NETLINK_NL_AUTO_H_
+
+#define _nl_auto(fcn)               __attribute__ ((__cleanup__(fcn)))
+
+#define _NL_AUTO_DEFINE_FCN_VOID0(CastType, name, func) \
+static inline void name(void *v) \
+{ \
+	if (*((CastType *) v)) \
+		func(*((CastType *) v)); \
+}
+
+#define _NL_AUTO_DEFINE_FCN_TYPED0(CastType, name, func) \
+static inline void name(CastType *v) \
+{ \
+	if (*v) \
+		func(*v); \
+}
+
+#define _nl_auto_free _nl_auto(_nl_auto_free_fcn)
+_NL_AUTO_DEFINE_FCN_VOID0(void *, _nl_auto_free_fcn, free)
+
+struct nl_addr;
+void nl_addr_put(struct nl_addr *);
+#define _nl_auto_nl_addr _nl_auto(_nl_auto_nl_addr_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct nl_addr *, _nl_auto_nl_addr_fcn, nl_addr_put)
+
+struct nl_msg;
+void nlmsg_free(struct nl_msg *);
+#define _nl_auto_nl_msg _nl_auto(_nl_auto_nl_msg_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct nl_msg *, _nl_auto_nl_msg_fcn, nlmsg_free)
+
+struct rtnl_link;
+void rtnl_link_put(struct rtnl_link *);
+#define _nl_auto_rtnl_link _nl_auto(_nl_auto_rtnl_link_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct rtnl_link *, _nl_auto_rtnl_link_fcn, rtnl_link_put)
+
+struct rtnl_route;
+void rtnl_route_put(struct rtnl_route *);
+#define _nl_auto_rtnl_route _nl_auto(_nl_auto_rtnl_route_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct rtnl_route *, _nl_auto_rtnl_route_fcn, rtnl_route_put)
+
+struct rtnl_nexthop;
+void rtnl_route_nh_free(struct rtnl_nexthop *);
+#define _nl_auto_rtnl_nexthop _nl_auto(_nl_auto_rtnl_nexthop_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct rtnl_nexthop *, _nl_auto_rtnl_nexthop_fcn, rtnl_route_nh_free)
+
+struct nl_cache;
+void nl_cache_put(struct nl_cache *);
+#define _nl_auto_nl_cache _nl_auto(_nl_auto_nl_cache_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct nl_cache *, _nl_auto_nl_cache_fcn, nl_cache_put)
+
+struct rtnl_link_af_ops;
+void rtnl_link_af_ops_put(struct rtnl_link_af_ops *);
+#define _nl_auto_rtnl_link_af_ops _nl_auto(_nl_auto_rtnl_link_af_ops_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct rtnl_link_af_ops *, _nl_auto_rtnl_link_af_ops_fcn, rtnl_link_af_ops_put)
+
+#endif /* NETLINK_NL_AUTO_H_ */

--- a/include/netlink-private/utils.h
+++ b/include/netlink-private/utils.h
@@ -83,18 +83,6 @@
 
 /*****************************************************************************/
 
-#define _NL_AUTO_DEFINE_FCN_VOID0(CastType, name, func) \
-static inline void name (void *v) \
-{ \
-	if (*((CastType *) v)) \
-		func (*((CastType *) v)); \
-}
-
-#define _nl_auto_free _nl_auto(_nl_auto_free_fcn)
-_NL_AUTO_DEFINE_FCN_VOID0 (void *, _nl_auto_free_fcn, free)
-
-/*****************************************************************************/
-
 extern const char *nl_strerror_l(int err);
 
 /*****************************************************************************/
@@ -219,5 +207,7 @@ _nl_strncpy(char *dst, const char *src, size_t len)
 
 	return dst;
 }
+
+#include "nl-auto.h"
 
 #endif

--- a/include/netlink-private/utils.h
+++ b/include/netlink-private/utils.h
@@ -180,7 +180,7 @@ _nl_strncpy_trunc(char *dst, const char *src, size_t len)
 }
 
 static inline char *
-_nl_strncpy(char *dst, const char *src, size_t len)
+_nl_strncpy_assert(char *dst, const char *src, size_t len)
 {
 	/* we don't use/reimplement strlcpy(), because we want the fill-all-with-NUL
 	 * behavior of strncpy(). This is just strncpy() with gracefully handling trunction
@@ -198,7 +198,7 @@ _nl_strncpy(char *dst, const char *src, size_t len)
 
 		/* Truncation is a bug and we assert against it. But note that this
 		 * assertion is disabled by default because we cannot be sure that
-		 * there are not wrong uses of _nl_strncpy() where truncation might
+		 * there are not wrong uses of _nl_strncpy_assert() where truncation might
 		 * happen (wrongly!!). */
 		_nl_assert (memchr(dst, '\0', len));
 

--- a/lib/attr.c
+++ b/lib/attr.c
@@ -257,7 +257,7 @@ int nla_parse(struct nlattr *tb[], int maxtype, struct nlattr *head, int len,
 		if (policy) {
 			err = validate_nla(nla, maxtype, policy);
 			if (err < 0)
-				goto errout;
+				return err;
 		}
 
 		if (tb[type])
@@ -267,13 +267,12 @@ int nla_parse(struct nlattr *tb[], int maxtype, struct nlattr *head, int len,
 		tb[type] = nla;
 	}
 
-	if (rem > 0)
+	if (rem > 0) {
 		NL_DBG(1, "netlink: %d bytes leftover after parsing "
 		       "attributes.\n", rem);
+	}
 
-	err = 0;
-errout:
-	return err;
+	return 0;
 }
 
 /**

--- a/lib/genl/family.c
+++ b/lib/genl/family.c
@@ -380,7 +380,7 @@ int genl_family_add_grp(struct genl_family *family, uint32_t id,
 		return -NLE_NOMEM;
 
 	grp->id = id;
-	_nl_strncpy(grp->name, name, GENL_NAMSIZ);
+	_nl_strncpy_assert(grp->name, name, GENL_NAMSIZ);
 
 	nl_list_add_tail(&grp->list, &family->gf_mc_grps);
 

--- a/lib/genl/family.c
+++ b/lib/genl/family.c
@@ -260,7 +260,7 @@ char *genl_family_get_name(struct genl_family *family)
  */
 void genl_family_set_name(struct genl_family *family, const char *name)
 {
-	strncpy(family->gf_name, name, GENL_NAMSIZ-1);
+	_nl_strncpy_trunc(family->gf_name, name, GENL_NAMSIZ);
 	family->ce_mask |= FAMILY_ATTR_NAME;
 }
 

--- a/lib/genl/mngt.c
+++ b/lib/genl/mngt.c
@@ -133,13 +133,13 @@ char *genl_op2name(int family, int op, char *buf, size_t len)
 			cmd = &ops->o_cmds[i];
 
 			if (cmd->c_id == op) {
-				strncpy(buf, cmd->c_name, len - 1);
+				_nl_strncpy_trunc(buf, cmd->c_name, len);
 				return buf;
 			}
 		}
 	}
 
-	strncpy(buf, "unknown", len - 1);
+	_nl_strncpy_trunc(buf, "unknown", len - 1);
 	return NULL;
 }
 

--- a/lib/route/act.c
+++ b/lib/route/act.c
@@ -125,7 +125,7 @@ int rtnl_act_fill(struct nl_msg *msg, int attrtype, struct rtnl_act *act)
 
 	while (p_act) {
 		err = rtnl_act_fill_one(msg, p_act, ++order);
-		if (err)
+		if (err < 0)
 			return err;
 		p_act = p_act->a_next;
 	}
@@ -519,8 +519,13 @@ static int act_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
 	p_act = act;
 	while(p_act) {
 		err = pp->pp_cb(OBJ_CAST(act), pp);
-		if (err)
+		if (err) {
+			if (err > 0) {
+				BUG();
+				err = -NLE_FAILURE;
+			}
 			break;
+		}
 		p_act = p_act->a_next;
 	}
 errout:

--- a/lib/route/cls/basic.c
+++ b/lib/route/cls/basic.c
@@ -93,7 +93,7 @@ static int basic_msg_parser(struct rtnl_tc *tc, void *data)
 	if (tb[TCA_BASIC_ACT]) {
 		b->b_mask |= BASIC_ATTR_ACTION;
 		err = rtnl_act_parse(&b->b_act, tb[TCA_BASIC_ACT]);
-		if (err)
+		if (err < 0)
 			return err;
 	}
 

--- a/lib/route/cls/ematch/text.c
+++ b/lib/route/cls/ematch/text.c
@@ -17,6 +17,7 @@
  */
 
 #include <netlink-private/netlink.h>
+#include <netlink-private/utils.h>
 #include <netlink-private/tc.h>
 #include <netlink/netlink.h>
 #include <netlink/route/cls/ematch.h>
@@ -91,7 +92,7 @@ void rtnl_ematch_text_set_algo(struct rtnl_ematch *e, const char *algo)
 {
 	struct text_data *t = rtnl_ematch_data(e);
 
-	strncpy(t->cfg.algo, algo, sizeof(t->cfg.algo));
+	_nl_strncpy_trunc(t->cfg.algo, algo, sizeof(t->cfg.algo));
 	t->cfg.algo[sizeof(t->cfg.algo) - 1] = '\0';
 }
 

--- a/lib/route/cls/mall.c
+++ b/lib/route/cls/mall.c
@@ -108,7 +108,7 @@ int rtnl_mall_append_action(struct rtnl_cls *cls, struct rtnl_act *act)
 
 	mall->m_mask |= MALL_ATTR_ACTION;
 	err = rtnl_act_append(&mall->m_act, act);
-	if (err)
+	if (err < 0)
 	        return err;
 
 	rtnl_act_get(act);
@@ -188,7 +188,7 @@ static int mall_msg_parser(struct rtnl_tc *tc, void *data)
 	if (tb[TCA_MATCHALL_ACT]) {
 		mall->m_mask |= MALL_ATTR_ACTION;
 		err = rtnl_act_parse(&mall->m_act, tb[TCA_MATCHALL_ACT]);
-		if (err)
+		if (err < 0)
 			return err;
 	}
 
@@ -212,13 +212,13 @@ static int mall_msg_fill(struct rtnl_tc *tc, void *data, struct nl_msg *msg)
 		int err;
 
 		err = rtnl_act_fill(msg, TCA_MATCHALL_ACT, mall->m_act);
-		if (err)
+		if (err < 0)
 			return err;
 	}
 
 	return 0;
 
- nla_put_failure:
+nla_put_failure:
 	return -NLE_NOMEM;
 }
 

--- a/lib/route/cls/u32.c
+++ b/lib/route/cls/u32.c
@@ -121,7 +121,7 @@ static int u32_msg_parser(struct rtnl_tc *tc, void *data)
 	if (tb[TCA_U32_ACT]) {
 		u->cu_mask |= U32_ATTR_ACTION;
 		err = rtnl_act_parse(&u->cu_act, tb[TCA_U32_ACT]);
-		if (err)
+		if (err < 0)
 			return err;
 	}
 
@@ -373,7 +373,7 @@ static int u32_msg_fill(struct rtnl_tc *tc, void *data, struct nl_msg *msg)
 		int err;
 
 		err = rtnl_act_fill(msg, TCA_U32_ACT, u->cu_act);
-		if (err)
+		if (err < 0)
 			return err;
 	}
 

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -722,6 +722,8 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
 			int remaining;
 
 			nla_for_each_nested(af_attr, tb[IFLA_AF_SPEC], remaining) {
+				_nl_auto_rtnl_link_af_ops struct rtnl_link_af_ops *af_ops = NULL;
+
 				af_ops = af_lookup_and_alloc(link, nla_type(af_attr));
 				if (af_ops && af_ops->ao_parse_af) {
 					char *af_data = link->l_af_data[nla_type(af_attr)];

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -730,7 +730,7 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
 
 					err = af_ops->ao_parse_af(link, af_attr, af_data);
 					if (err < 0)
-						goto errout;
+						return err;
 				}
 			}
 			link->ce_mask |= LINK_ATTR_AF_SPEC;

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -818,13 +818,13 @@ static int link_request_update(struct nl_cache *cache, struct nl_sock *sk)
 	ops = rtnl_link_af_ops_lookup(family);
 	if (ops && ops->ao_get_af) {
 		err = ops->ao_get_af(msg, &ext_filter_mask);
-		if (err)
+		if (err < 0)
 			goto nla_put_failure;
 	}
 
 	if (ext_filter_mask) {
 		err = nla_put(msg, IFLA_EXT_MASK, sizeof(ext_filter_mask), &ext_filter_mask);
-		if (err)
+		if (err < 0)
 			goto nla_put_failure;
 	}
 
@@ -1396,7 +1396,7 @@ int rtnl_link_build_get_request(int ifindex, const char *name,
 		NLA_PUT_STRING(msg, IFLA_IFNAME, name);
 
 	err = nla_put(msg, IFLA_EXT_MASK, sizeof(vf_mask), &vf_mask);
-	if (err)
+	if (err < 0)
 		goto nla_put_failure;
 
 	*result = msg;

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -1487,7 +1487,7 @@ char * rtnl_link_i2name(struct nl_cache *cache, int ifindex, char *dst,
 	struct rtnl_link *link = rtnl_link_get(cache, ifindex);
 
 	if (link) {
-		strncpy(dst, link->l_name, len - 1);
+		_nl_strncpy_trunc(dst, link->l_name, len);
 		rtnl_link_put(link);
 		return dst;
 	}
@@ -1958,7 +1958,7 @@ void rtnl_link_put(struct rtnl_link *link)
  */
 void rtnl_link_set_name(struct rtnl_link *link, const char *name)
 {
-	strncpy(link->l_name, name, sizeof(link->l_name) - 1);
+	_nl_strncpy_trunc(link->l_name, name, sizeof(link->l_name));
 	link->ce_mask |= LINK_ATTR_IFNAME;
 }
 
@@ -2482,7 +2482,7 @@ void rtnl_link_set_ifalias(struct rtnl_link *link, const char *alias)
  */
 void rtnl_link_set_qdisc(struct rtnl_link *link, const char *name)
 {
-	strncpy(link->l_qdisc, name, sizeof(link->l_qdisc) - 1);
+	_nl_strncpy_trunc(link->l_qdisc, name, sizeof(link->l_qdisc));
 	link->ce_mask |= LINK_ATTR_QDISC;
 }
 

--- a/lib/route/neightbl.c
+++ b/lib/route/neightbl.c
@@ -18,6 +18,7 @@
  */
 
 #include <netlink-private/netlink.h>
+#include <netlink-private/utils.h>
 #include <netlink/netlink.h>
 #include <netlink/utils.h>
 #include <netlink/route/rtnl.h>
@@ -631,7 +632,7 @@ void rtnl_neightbl_set_gc_tresh3(struct rtnl_neightbl *ntbl, int thresh)
 
 void rtnl_neightbl_set_name(struct rtnl_neightbl *ntbl, const char *name)
 {
-	strncpy(ntbl->nt_name, name, sizeof(ntbl->nt_name) - 1);
+	_nl_strncpy_trunc(ntbl->nt_name, name, sizeof(ntbl->nt_name));
 	ntbl->ce_mask |= NEIGHTBL_ATTR_NAME;
 }
 

--- a/lib/route/nexthop_encap.c
+++ b/lib/route/nexthop_encap.c
@@ -55,7 +55,7 @@ int nh_encap_build_msg(struct nl_msg *msg, struct rtnl_nh_encap *rtnh_encap)
 		goto nla_put_failure;
 
 	err = rtnh_encap->ops->build_msg(msg, rtnh_encap->priv);
-	if (err)
+	if (err < 0)
 		return err;
 
 	nla_nest_end(msg, encap);

--- a/lib/route/nh_encap_mpls.c
+++ b/lib/route/nh_encap_mpls.c
@@ -34,7 +34,7 @@ static int mpls_encap_build_msg(struct nl_msg *msg, void *priv)
 	return 0;
 
 nla_put_failure:
-        return -NLE_MSGSIZE;
+	return -NLE_MSGSIZE;
 }
 
 static void mpls_encap_destructor(void *priv)
@@ -56,9 +56,8 @@ static int mpls_encap_parse_msg(struct nlattr *nla, struct rtnl_nexthop *nh)
 	uint8_t ttl = 0;
 	int err;
 
-
 	err = nla_parse_nested(tb, MPLS_IPTUNNEL_MAX, nla, mpls_encap_policy);
-	if (err)
+	if (err < 0)
 		return err;
 
 	if (!tb[MPLS_IPTUNNEL_DST])

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -1077,7 +1077,7 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 
 				err = rtnl_route_nh_set_newdst(nh, addr);
 				nl_addr_put(addr);
-				if (err)
+				if (err < 0)
 					goto errout;
 			}
 
@@ -1090,7 +1090,7 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 
 				err = rtnl_route_nh_set_via(nh, addr);
 				nl_addr_put(addr);
-				if (err)
+				if (err < 0)
 					goto errout;
 			}
 
@@ -1098,7 +1098,7 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 				err = nh_encap_parse_msg(ntb[RTA_ENCAP],
 							 ntb[RTA_ENCAP_TYPE],
 							 nh);
-				if (err)
+				if (err < 0)
 					goto errout;
 			}
 		}
@@ -1267,7 +1267,7 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 		err = rtnl_route_nh_set_newdst(old_nh, addr);
 		nl_addr_put(addr);
-		if (err)
+		if (err < 0)
 			goto errout;
 	}
 
@@ -1284,7 +1284,7 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 		err = rtnl_route_nh_set_via(old_nh, addr);
 		nl_addr_put(addr);
-		if (err)
+		if (err < 0)
 			goto errout;
 	}
 
@@ -1299,7 +1299,7 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 		err = nh_encap_parse_msg(tb[RTA_ENCAP],
 					 tb[RTA_ENCAP_TYPE], old_nh);
-		if (err)
+		if (err < 0)
 			goto errout;
 	}
 

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -1072,8 +1072,10 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 
 				addr = nl_addr_alloc_attr(ntb[RTA_NEWDST],
 							  route->rt_family);
-				if (!addr)
+				if (!addr) {
+					err = -NLE_NOMEM;
 					goto errout;
+				}
 
 				err = rtnl_route_nh_set_newdst(nh, addr);
 				nl_addr_put(addr);
@@ -1085,8 +1087,10 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 				struct nl_addr *addr;
 
 				addr = rtnl_route_parse_via(ntb[RTA_VIA]);
-				if (!addr)
+				if (!addr) {
+					err = -NLE_NOMEM;
 					goto errout;
+				}
 
 				err = rtnl_route_nh_set_via(nh, addr);
 				nl_addr_put(addr);

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -211,8 +211,8 @@ static void route_dump_line(struct nl_object *a, struct nl_dump_params *p)
 
 static void route_dump_details(struct nl_object *a, struct nl_dump_params *p)
 {
+	_nl_auto_nl_cache struct nl_cache *link_cache = NULL;
 	struct rtnl_route *r = (struct rtnl_route *) a;
-	struct nl_cache *link_cache;
 	char buf[256];
 	int i;
 
@@ -282,9 +282,6 @@ static void route_dump_details(struct nl_object *a, struct nl_dump_params *p)
 					r->rt_metrics[i]);
 		nl_dump(p, "]\n");
 	}
-
-	if (link_cache)
-		nl_cache_put(link_cache);
 }
 
 static void route_dump_stats(struct nl_object *obj, struct nl_dump_params *p)
@@ -310,7 +307,7 @@ static void route_keygen(struct nl_object *obj, uint32_t *hashkey,
 	struct rtnl_route *route = (struct rtnl_route *) obj;
 	unsigned int rkey_sz;
 	struct nl_addr *addr = NULL;
-	struct route_hash_key {
+	_nl_auto_free struct route_hash_key {
 		uint8_t		rt_family;
 		uint8_t		rt_tos;
 		uint32_t	rt_table;
@@ -347,8 +344,6 @@ static void route_keygen(struct nl_object *obj, uint32_t *hashkey,
 		"hash 0x%x\n", route, rkey->rt_family, rkey->rt_tos,
 		rkey->rt_table, nl_addr2str(addr, buf, sizeof(buf)),
 		rkey_sz, *hashkey);
-
-	free(rkey);
 
 	return;
 }
@@ -1022,12 +1017,13 @@ static struct nla_policy route_policy[RTA_MAX+1] = {
 
 static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 {
-	struct rtnl_nexthop *nh = NULL;
 	struct rtnexthop *rtnh = nla_data(attr);
 	size_t tlen = nla_len(attr);
 	int err;
 
 	while (tlen >= sizeof(*rtnh) && tlen >= rtnh->rtnh_len) {
+		_nl_auto_rtnl_nexthop struct rtnl_nexthop *nh = NULL;
+
 		nh = rtnl_route_nh_alloc();
 		if (!nh)
 			return -NLE_NOMEM;
@@ -1044,20 +1040,17 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 					rtnh->rtnh_len - sizeof(*rtnh),
 					route_policy);
 			if (err < 0)
-				goto errout;
+				return err;
 
 			if (ntb[RTA_GATEWAY]) {
-				struct nl_addr *addr;
+				_nl_auto_nl_addr struct nl_addr *addr = NULL;
 
 				addr = nl_addr_alloc_attr(ntb[RTA_GATEWAY],
 							  route->rt_family);
-				if (!addr) {
-					err = -NLE_NOMEM;
-					goto errout;
-				}
+				if (!addr)
+					return -NLE_NOMEM;
 
 				rtnl_route_nh_set_gateway(nh, addr);
-				nl_addr_put(addr);
 			}
 
 			if (ntb[RTA_FLOW]) {
@@ -1068,34 +1061,28 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 			}
 
 			if (ntb[RTA_NEWDST]) {
-				struct nl_addr *addr;
+				_nl_auto_nl_addr struct nl_addr *addr = NULL;
 
 				addr = nl_addr_alloc_attr(ntb[RTA_NEWDST],
 							  route->rt_family);
-				if (!addr) {
-					err = -NLE_NOMEM;
-					goto errout;
-				}
+				if (!addr)
+					return -NLE_NOMEM;
 
 				err = rtnl_route_nh_set_newdst(nh, addr);
-				nl_addr_put(addr);
 				if (err < 0)
-					goto errout;
+					return err;
 			}
 
 			if (ntb[RTA_VIA]) {
-				struct nl_addr *addr;
+				_nl_auto_nl_addr struct nl_addr *addr = NULL;
 
 				addr = rtnl_route_parse_via(ntb[RTA_VIA]);
-				if (!addr) {
-					err = -NLE_NOMEM;
-					goto errout;
-				}
+				if (!addr)
+					return -NLE_NOMEM;
 
 				err = rtnl_route_nh_set_via(nh, addr);
-				nl_addr_put(addr);
 				if (err < 0)
-					goto errout;
+					return err;
 			}
 
 			if (ntb[RTA_ENCAP] && ntb[RTA_ENCAP_TYPE]) {
@@ -1103,7 +1090,7 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 							 ntb[RTA_ENCAP_TYPE],
 							 nh);
 				if (err < 0)
-					goto errout;
+					return err;
 			}
 		}
 
@@ -1112,32 +1099,29 @@ static int parse_multipath(struct rtnl_route *route, struct nlattr *attr)
 		rtnh = RTNH_NEXT(rtnh);
 	}
 
-	err = 0;
-errout:
-	if (err && nh)
-		rtnl_route_nh_free(nh);
-
-	return err;
+	return 0;
 }
 
 int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 {
-	struct rtmsg *rtm;
-	struct rtnl_route *route;
+	_nl_auto_rtnl_route struct rtnl_route *route = NULL;
+	_nl_auto_rtnl_nexthop struct rtnl_nexthop *old_nh = NULL;
+	_nl_auto_nl_addr struct nl_addr *src = NULL;
+	_nl_auto_nl_addr struct nl_addr *dst = NULL;
 	struct nlattr *tb[RTA_MAX + 1];
-	struct nl_addr *src = NULL, *dst = NULL, *addr;
-	struct rtnl_nexthop *old_nh = NULL;
-	int err, family;
+	struct rtmsg *rtm;
+	int family;
+	int err;
 
 	route = rtnl_route_alloc();
 	if (!route)
-		goto errout_nomem;
+		return -NLE_NOMEM;
 
 	route->ce_msgtype = nlh->nlmsg_type;
 
 	err = nlmsg_parse(nlh, sizeof(struct rtmsg), tb, RTA_MAX, route_policy);
 	if (err < 0)
-		goto errout;
+		return err;
 
 	rtm = nlmsg_data(nlh);
 	route->rt_family = family = rtm->rtm_family;
@@ -1162,31 +1146,28 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 	if (tb[RTA_DST]) {
 		if (!(dst = nl_addr_alloc_attr(tb[RTA_DST], family)))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 	} else {
 		if (!(dst = nl_addr_alloc(0)))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 		nl_addr_set_family(dst, rtm->rtm_family);
 	}
 
 	nl_addr_set_prefixlen(dst, rtm->rtm_dst_len);
 	err = rtnl_route_set_dst(route, dst);
 	if (err < 0)
-		goto errout;
-
-	nl_addr_put(dst);
+		return err;
 
 	if (tb[RTA_SRC]) {
 		if (!(src = nl_addr_alloc_attr(tb[RTA_SRC], family)))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 	} else if (rtm->rtm_src_len)
 		if (!(src = nl_addr_alloc(0)))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 	if (src) {
 		nl_addr_set_prefixlen(src, rtm->rtm_src_len);
 		rtnl_route_set_src(route, src);
-		nl_addr_put(src);
 	}
 
 	if (tb[RTA_TABLE])
@@ -1199,10 +1180,11 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 		rtnl_route_set_priority(route, nla_get_u32(tb[RTA_PRIORITY]));
 
 	if (tb[RTA_PREFSRC]) {
+		_nl_auto_nl_addr struct nl_addr *addr = NULL;
+
 		if (!(addr = nl_addr_alloc_attr(tb[RTA_PREFSRC], family)))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 		rtnl_route_set_pref_src(route, addr);
-		nl_addr_put(addr);
 	}
 
 	if (tb[RTA_METRICS]) {
@@ -1211,7 +1193,7 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 		err = nla_parse_nested(mtb, RTAX_MAX, tb[RTA_METRICS], NULL);
 		if (err < 0)
-			goto errout;
+			return err;
 
 		for (i = 1; i <= RTAX_MAX; i++) {
 			if (mtb[i] && nla_len(mtb[i]) >= sizeof(uint32_t)) {
@@ -1219,14 +1201,15 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 				err = rtnl_route_set_metric(route, i, m);
 				if (err < 0)
-					goto errout;
+					return err;
 			}
 		}
 	}
 
-	if (tb[RTA_MULTIPATH])
+	if (tb[RTA_MULTIPATH]) {
 		if ((err = parse_multipath(route, tb[RTA_MULTIPATH])) < 0)
-			goto errout;
+			return err;
+	}
 
 	if (tb[RTA_CACHEINFO]) {
 		nla_memcpy(&route->rt_cacheinfo, tb[RTA_CACHEINFO],
@@ -1236,60 +1219,60 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 	if (tb[RTA_OIF]) {
 		if (!old_nh && !(old_nh = rtnl_route_nh_alloc()))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		rtnl_route_nh_set_ifindex(old_nh, nla_get_u32(tb[RTA_OIF]));
 	}
 
 	if (tb[RTA_GATEWAY]) {
+		_nl_auto_nl_addr struct nl_addr *addr = NULL;
+
 		if (!old_nh && !(old_nh = rtnl_route_nh_alloc()))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		if (!(addr = nl_addr_alloc_attr(tb[RTA_GATEWAY], family)))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		rtnl_route_nh_set_gateway(old_nh, addr);
-		nl_addr_put(addr);
 	}
 
 	if (tb[RTA_FLOW]) {
 		if (!old_nh && !(old_nh = rtnl_route_nh_alloc()))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		rtnl_route_nh_set_realms(old_nh, nla_get_u32(tb[RTA_FLOW]));
 	}
 
 	if (tb[RTA_NEWDST]) {
-		struct nl_addr *addr;
+		_nl_auto_nl_addr struct nl_addr *addr;
 
 		if (!old_nh && !(old_nh = rtnl_route_nh_alloc()))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		addr = nl_addr_alloc_attr(tb[RTA_NEWDST], route->rt_family);
 		if (!addr)
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		err = rtnl_route_nh_set_newdst(old_nh, addr);
-		nl_addr_put(addr);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	if (tb[RTA_VIA]) {
 		int alen = nla_len(tb[RTA_VIA]) - offsetof(struct rtvia, rtvia_addr);
+		_nl_auto_nl_addr struct nl_addr *addr = NULL;
 		struct rtvia *via = nla_data(tb[RTA_VIA]);
 
 		if (!old_nh && !(old_nh = rtnl_route_nh_alloc()))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		addr = nl_addr_build(via->rtvia_family, via->rtvia_addr, alen);
 		if (!addr)
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		err = rtnl_route_nh_set_via(old_nh, addr);
-		nl_addr_put(addr);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	if (tb[RTA_TTL_PROPAGATE]) {
@@ -1299,12 +1282,12 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 	if (tb[RTA_ENCAP] && tb[RTA_ENCAP_TYPE]) {
 		if (!old_nh && !(old_nh = rtnl_route_nh_alloc()))
-			goto errout_nomem;
+			return -NLE_NOMEM;
 
 		err = nh_encap_parse_msg(tb[RTA_ENCAP],
 					 tb[RTA_ENCAP_TYPE], old_nh);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	if (old_nh) {
@@ -1313,7 +1296,7 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 			/* If no nexthops have been provided via RTA_MULTIPATH
 			 * we add it as regular nexthop to maintain backwards
 			 * compatibility */
-			rtnl_route_add_nexthop(route, old_nh);
+			rtnl_route_add_nexthop(route, _nl_steal_pointer(&old_nh));
 		} else {
 			/* Kernel supports new style nexthop configuration,
 			 * verify that it is a duplicate and discard nexthop. */
@@ -1327,27 +1310,13 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
 
 			if (rtnl_route_nh_compare(old_nh, first,
 						  old_nh->ce_mask, 0)) {
-				err = -NLE_INVAL;
-				goto errout;
+				return -NLE_INVAL;
 			}
-
-			rtnl_route_nh_free(old_nh);
 		}
-		old_nh = NULL;
 	}
 
-	*result = route;
+	*result = _nl_steal_pointer(&route);
 	return 0;
-
-errout:
-	if (old_nh)
-		rtnl_route_nh_free(old_nh);
-	rtnl_route_put(route);
-	return err;
-
-errout_nomem:
-	err = -NLE_NOMEM;
-	goto errout;
 }
 
 int rtnl_route_build_msg(struct nl_msg *msg, struct rtnl_route *route)

--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -536,7 +536,7 @@ int rtnl_tc_set_kind(struct rtnl_tc *tc, const char *kind)
 	    || strlen (kind) >= sizeof (tc->tc_kind))
 		return -NLE_INVAL;
 
-	_nl_strncpy(tc->tc_kind, kind, sizeof(tc->tc_kind));
+	_nl_strncpy_assert(tc->tc_kind, kind, sizeof(tc->tc_kind));
 
 	tc->ce_mask |= TCA_ATTR_KIND;
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -475,7 +475,7 @@ static void get_psched_settings(void)
 		else if ((ev = getenv("PROC_ROOT")))
 			snprintf(name, sizeof(name), "%s/net/psched", ev);
 		else
-			strncpy(name, "/proc/net/psched", sizeof(name) - 1);
+			_nl_strncpy_assert(name, "/proc/net/psched", sizeof(name));
 
 		if ((fd = fopen(name, "re"))) {
 			unsigned int ns_per_usec, ns_per_tick, nom, denom;

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -1192,7 +1192,7 @@ static int build_xfrm_sa_message(struct xfrmnl_sa *tmpl, int cmd, int flags, str
 				return -NLE_NOMEM;
 			}
 
-			strncpy(auth->alg_name, tmpl->auth->alg_name, sizeof(auth->alg_name));
+			_nl_strncpy_assert(auth->alg_name, tmpl->auth->alg_name, sizeof(auth->alg_name));
 			auth->alg_name[sizeof(auth->alg_name) - 1] = '\0';
 			auth->alg_key_len = tmpl->auth->alg_key_len;
 			memcpy(auth->alg_key, tmpl->auth->alg_key, (tmpl->auth->alg_key_len + 7) / 8);


### PR DESCRIPTION
various cleanups.


We should use more `__attribute__((cleanup))` and simplify error paths by returning early.