### PR TITLE
neigh: support to add fdb entry

### DIFF
--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -709,7 +709,7 @@ static int build_neigh_msg(struct rtnl_neigh *tmpl, int cmd, int flags,
 	if (nlmsg_append(msg, &nhdr, sizeof(nhdr), NLMSG_ALIGNTO) < 0)
 		goto nla_put_failure;
 
-	if (tmpl->n_family != AF_BRIDGE)
+	if (tmpl->ce_mask & NEIGH_ATTR_DST)
 		NLA_PUT_ADDR(msg, NDA_DST, tmpl->n_dst);
 
 	if (tmpl->ce_mask & NEIGH_ATTR_LLADDR)


### PR DESCRIPTION
rtnl_neigh.n_family should be set as AF_BRIDGE when we want to add a fdb entry,
but the func build_neigh_msg does not allow dst addr to be put at that time.

Here is the example:
    struct rtnl_neigh *neigh = rtnl_neigh_alloc();
    struct nl_addr *mac = nl_addr_build(AF_LLC, eth, ETH_ALEN);
    struct nl_addr *dst = nl_addr_build(AF_INET, addr, 4);

    rtnl_neigh_set_ifindex(neigh, rtnl_link_get_ifindex(vxlan_link));
    rtnl_neigh_set_state(neigh, NUD_NOARP | NUD_PERMANENT);
    rtnl_neigh_set_lladdr(neigh, mac);
    rtnl_neigh_set_flags(neigh, NTF_SELF);
    rtnl_neigh_set_dst(neigh, dst);
    rtnl_neigh_set_family(neigh, AF_BRIDGE);

    rtnl_neigh_add(sk, neigh, NLM_F_CREATE);

Then command "bridge fdb show" will print out the fdb entry:
02:68:60:19:6b:a4 dev flannel.1 dst 10.40.252.12 self permanent

Signed-off-by: huangxuesen <huangxuesen@kuaishou.com>
Signed-off-by: wangli09 <wangli09@kuaishou.com>