### PR TITLE
Let route/link join RTNLGRP_IPV6_IFINFO mcast group

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -3163,6 +3163,7 @@ static struct nl_object_ops link_obj_ops = {
 static struct nl_af_group link_groups[] = {
 	{ AF_UNSPEC,	RTNLGRP_LINK },
 	{ AF_BRIDGE,    RTNLGRP_LINK },
+	{ AF_INET6,     RTNLGRP_IPV6_IFINFO },
 	{ END_OF_GROUP_LIST },
 };
 


### PR DESCRIPTION
Required to be notified about inet6 managed/otherconf flag changes, see
occurrences of `inet6_ifinfo_notify` in `net/ipv6/ndisc.c` of the Linux
kernel.
