### PR TITLE
doc: update link to mscgen-filter

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -4,7 +4,7 @@ mscgen
   http://www.mcternan.me.uk/mscgen/
 
 mscgen-filter-1.2
-  http://code.google.com/p/asciidoc-mscgen-filter/
+  https://github.com/hwmaier/asciidoc-mscgen-filter
 
 asciidoc > 8.6.x
 doxygen > 1.8.0


### PR DESCRIPTION
They actually added `Version: 1.2` line to their README back in 2015, but never tagged it nor published it on GitHub Releases page. I've submitted a request for a tag: https://github.com/hwmaier/asciidoc-mscgen-filter/issues/3.