### PR TITLE
Bugfixed CAN support. Added CAN FD support.

### DIFF
--- a/include/netlink/route/link/can.h
+++ b/include/netlink/route/link/can.h
@@ -51,6 +51,19 @@ extern int rtnl_link_can_get_ctrlmode(struct rtnl_link *, uint32_t *);
 extern int rtnl_link_can_set_ctrlmode(struct rtnl_link *, uint32_t);
 extern int rtnl_link_can_unset_ctrlmode(struct rtnl_link *, uint32_t);
 
+extern int rtnl_link_can_get_data_bt_const(struct rtnl_link *,
+														 struct can_bittiming_const *);
+extern int rtnl_link_can_get_data_bittiming(struct rtnl_link *,
+														  struct can_bittiming *);
+extern int rtnl_link_can_set_data_bittiming(struct rtnl_link *,
+														  struct can_bittiming *);
+
+extern int rtnl_link_can_get_data_bitrate(struct rtnl_link *, uint32_t *);
+extern int rtnl_link_can_set_data_bitrate(struct rtnl_link *, uint32_t);
+
+extern int rtnl_link_can_get_data_sample_point(struct rtnl_link *, uint32_t *);
+extern int rtnl_link_can_set_data_sample_point(struct rtnl_link *, uint32_t);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
 - Don't use internal bit mask constants in NLA_PUT:s. That caused most set-functions to fail.
 - Added CAN FD support analog to the normal CAN support.