### PR TITLE
lib: check duplicates in cache refill, fix descriptions

### DIFF
--- a/lib/cache.c
+++ b/lib/cache.c
@@ -751,7 +751,10 @@ static int __nl_cache_pickup(struct nl_sock *sk, struct nl_cache *cache,
  * @arg cache		Cache to put items into.
  *
  * Waits for netlink messages to arrive, parses them and puts them into
- * the specified cache.
+ * the specified cache. If an old object with same key attributes is
+ * present in the cache, it is replaced with the new object.
+ * If the old object type supports an update operation, an update is
+ * attempted before a replace.
  *
  * @return 0 on success or a negative error code.
  */
@@ -766,10 +769,7 @@ int nl_cache_pickup_checkdup(struct nl_sock *sk, struct nl_cache *cache)
  * @arg cache		Cache to put items into.
  *
  * Waits for netlink messages to arrive, parses them and puts them into
- * the specified cache. If an old object with same key attributes is
- * present in the cache, it is replaced with the new object.
- * If the old object type supports an update operation, an update is
- * attempted before a replace.
+ * the specified cache.
  *
  * @return 0 on success or a negative error code.
  */
@@ -1055,7 +1055,7 @@ restart:
 		NL_DBG(2, "Updating cache %p <%s> for family %u, request sent, waiting for reply\n",
 		       cache, nl_cache_name(cache), grp ? grp->ag_family : AF_UNSPEC);
 
-		err = nl_cache_pickup(sk, cache);
+		err = nl_cache_pickup_checkdup(sk, cache);
 		if (err == -NLE_DUMP_INTR) {
 			NL_DBG(2, "Dump interrupted, restarting!\n");
 			goto restart;


### PR DESCRIPTION
Using `nl_cache_pickup_checkdup` while refilling the cache resolves the issue which I reported some time ago #271.

I've also swapped descriptions of `nl_cache_pickup` and `nl_cache_pickup_checkdup ` cause it looks like the second one performs update.