### PR TITLE
netfilter/ct: fix use of reply/orig for conntrack requests

### DIFF
--- a/lib/netfilter/ct.c
+++ b/lib/netfilter/ct.c
@@ -507,20 +507,24 @@ static int nfnl_ct_build_message(const struct nfnl_ct *ct, int cmd, int flags,
 {
 	struct nl_msg *msg;
 	int err;
+	int reply = 0;
 
 	msg = nfnlmsg_alloc_simple(NFNL_SUBSYS_CTNETLINK, cmd, flags,
 				   nfnl_ct_get_family(ct), 0);
 	if (msg == NULL)
 		return -NLE_NOMEM;
 
-	if ((err = nfnl_ct_build_tuple(msg, ct, 0)) < 0)
-		goto err_out;
-
-	/* REPLY tuple is optional, dont add unless at least src/dst specified */
-
-	if ( nfnl_ct_get_src(ct, 1) && nfnl_ct_get_dst(ct, 1) )
+	/* We use REPLY || ORIG, depending on requests. */
+	if (nfnl_ct_get_src(ct, 1) || nfnl_ct_get_dst(ct, 1)) {
+		reply = 1;
 		if ((err = nfnl_ct_build_tuple(msg, ct, 1)) < 0)
 			goto err_out;
+	}
+
+	if (!reply || nfnl_ct_get_src(ct, 0) || nfnl_ct_get_dst(ct, 0)) {
+		if ((err = nfnl_ct_build_tuple(msg, ct, 0)) < 0)
+			goto err_out;
+	}
 
 	if (nfnl_ct_test_status(ct))
 		NLA_PUT_U32(msg, CTA_STATUS, htonl(nfnl_ct_get_status(ct)));


### PR DESCRIPTION
It's impossible to query conntrack entries (GET message, but with no flags because of a Linux ABI issue) based on reply tuple using libnl and nfnl_ct_build_message. That's because even if we don't set any orig (repy == 0) field in a nfnl_ct, nfnl_ct_build_message will build the tuple with ORIG anyway, and then add the REPLY fields. And then the kernel will check if ORIG is present, and match only on this orig, even if it's missing tuple fields and reply has all fields.

Fix this by building the query only with reply, only with orig, or both, and only fallback with an orig tuple when no field is specified (e.g a dump request).

Fixes #281