### PR TITLE
Upstream SONiC MPLS changes to libnl3

### DIFF
--- a/include/netlink/route/nexthop.h
+++ b/include/netlink/route/nexthop.h
@@ -64,6 +64,8 @@ extern int		rtnl_route_nh_str2flags(const char *);
 extern int		rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
 						 struct nl_addr *addr,
 						 uint8_t ttl);
+extern struct nl_addr *	rtnl_route_nh_get_encap_mpls_dst(struct rtnl_nexthop *);
+extern uint8_t		rtnl_route_nh_get_encap_mpls_ttl(struct rtnl_nexthop *);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/route/nexthop.c
+++ b/lib/route/nexthop.c
@@ -344,10 +344,6 @@ int rtnl_route_nh_set_newdst(struct rtnl_nexthop *nh, struct nl_addr *addr)
 {
 	struct nl_addr *old = nh->rtnh_newdst;
 
-	if (!nl_addr_valid(nl_addr_get_binary_addr(addr),
-			   nl_addr_get_len(addr)))
-		return -NLE_INVAL;
-
 	if (addr) {
 		nh->rtnh_newdst = nl_addr_get(addr);
 		nh->ce_mask |= NH_ATTR_NEWDST;
@@ -370,10 +366,6 @@ struct nl_addr *rtnl_route_nh_get_newdst(struct rtnl_nexthop *nh)
 int rtnl_route_nh_set_via(struct rtnl_nexthop *nh, struct nl_addr *addr)
 {
 	struct nl_addr *old = nh->rtnh_via;
-
-	if (!nl_addr_valid(nl_addr_get_binary_addr(addr),
-			   nl_addr_get_len(addr)))
-		return -NLE_INVAL;
 
 	if (addr) {
 		nh->rtnh_via = nl_addr_get(addr);

--- a/lib/route/nh_encap_mpls.c
+++ b/lib/route/nh_encap_mpls.c
@@ -108,10 +108,6 @@ int rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
 	if (!addr)
 		return -NLE_INVAL;
 
-	if (!nl_addr_valid(nl_addr_get_binary_addr(addr),
-			   nl_addr_get_len(addr)))
-		return -NLE_INVAL;
-
 	rtnh_encap = calloc(1, sizeof(*rtnh_encap));
 	if (!rtnh_encap)
 		return -NLE_NOMEM;
@@ -131,4 +127,32 @@ int rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
 	nh_set_encap(nh, rtnh_encap);
 
 	return 0;
+}
+
+struct nl_addr *rtnl_route_nh_get_encap_mpls_dst(struct rtnl_nexthop *nh)
+{
+	struct mpls_iptunnel_encap *mpls_encap;
+
+	if (!nh->rtnh_encap || nh->rtnh_encap->ops->encap_type != LWTUNNEL_ENCAP_MPLS)
+		return NULL;
+
+	mpls_encap = (struct mpls_iptunnel_encap *)nh->rtnh_encap->priv;
+	if (!mpls_encap)
+		return NULL;
+
+	return mpls_encap->dst;
+}
+
+uint8_t rtnl_route_nh_get_encap_mpls_ttl(struct rtnl_nexthop *nh)
+{
+	struct mpls_iptunnel_encap *mpls_encap;
+
+	if (!nh->rtnh_encap || nh->rtnh_encap->ops->encap_type != LWTUNNEL_ENCAP_MPLS)
+		return 0;
+
+	mpls_encap = (struct mpls_iptunnel_encap *)nh->rtnh_encap->priv;
+	if (!mpls_encap)
+		return 0;
+
+	return mpls_encap->ttl;
 }

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1127,6 +1127,8 @@ global:
 	rtnl_qdisc_mqprio_set_priomap;
 	rtnl_qdisc_mqprio_set_queue;
 	rtnl_qdisc_mqprio_set_shaper;
+	rtnl_route_nh_get_encap_mpls_dst;
+	rtnl_route_nh_get_encap_mpls_ttl;
 	rtnl_rule_get_dport;
 	rtnl_rule_get_ipproto;
 	rtnl_rule_get_protocol;


### PR DESCRIPTION
libnl 3.5.0 is currently used by the open-source project SONiC (https://github.com/Azure/sonic-buildimage.git)
Several patches are made to the SONiC version of libnl to better support MPLS.
The purpose of this PR is to upstream these SONiC MPLS changes to libnl for general usage.
1) New accessors for setting/getting ENCAP_MPLS attributes.
2) Removed incorrect usage of nl_addr_valid() from NEWDST and ENCAP_MPLS DST processing.