### PR TITLE
cli: Add C++ linkage support

### DIFF
--- a/include/netlink/cli/addr.h
+++ b/include/netlink/cli/addr.h
@@ -8,6 +8,10 @@
 
 #include <netlink/route/addr.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define nl_cli_addr_alloc_cache(sk) \
 		nl_cli_alloc_cache((sk), "address", rtnl_addr_alloc_cache)
 
@@ -22,5 +26,9 @@ extern void nl_cli_addr_parse_scope(struct rtnl_addr *, char *);
 extern void nl_cli_addr_parse_broadcast(struct rtnl_addr *, char *);
 extern void nl_cli_addr_parse_preferred(struct rtnl_addr *, char *);
 extern void nl_cli_addr_parse_valid(struct rtnl_addr *, char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/class.h
+++ b/include/netlink/cli/class.h
@@ -9,7 +9,15 @@
 #include <netlink/route/class.h>
 #include <netlink/cli/tc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct rtnl_class *nl_cli_class_alloc(void);
 extern struct nl_cache *nl_cli_class_alloc_cache(struct nl_sock *, int);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/cls.h
+++ b/include/netlink/cli/cls.h
@@ -9,10 +9,18 @@
 #include <netlink/route/classifier.h>
 #include <netlink/cli/tc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct rtnl_cls *	nl_cli_cls_alloc(void);
 extern struct nl_cache *	nl_cli_cls_alloc_cache(struct nl_sock *,
 						       int, uint32_t);
 extern void			nl_cli_cls_parse_proto(struct rtnl_cls *, char *);
 extern struct rtnl_ematch_tree *nl_cli_cls_parse_ematch(struct rtnl_cls *, char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/ct.h
+++ b/include/netlink/cli/ct.h
@@ -9,6 +9,10 @@
 #include <netlink/netfilter/ct.h>
 #include <linux/netfilter/nf_conntrack_common.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct nfnl_ct *nl_cli_ct_alloc(void);
 extern struct nl_cache *nl_cli_ct_alloc_cache(struct nl_sock *);
 
@@ -25,5 +29,9 @@ extern void nl_cli_ct_parse_dst_port(struct nfnl_ct *, int, char *);
 extern void nl_cli_ct_parse_tcp_state(struct nfnl_ct *, char *);
 extern void nl_cli_ct_parse_status(struct nfnl_ct *, char *);
 extern void nl_cli_ct_parse_zone(struct nfnl_ct *, char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/exp.h
+++ b/include/netlink/cli/exp.h
@@ -10,6 +10,10 @@
 #include <netlink/netfilter/exp.h>
 #include <linux/netfilter/nf_conntrack_common.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct nfnl_exp *nl_cli_exp_alloc(void);
 extern struct nl_cache *nl_cli_exp_alloc_cache(struct nl_sock *);
 
@@ -32,5 +36,8 @@ extern void nl_cli_exp_parse_icmp_id(struct nfnl_exp *, int, char *);
 extern void nl_cli_exp_parse_icmp_type(struct nfnl_exp *, int, char *);
 extern void nl_cli_exp_parse_icmp_code(struct nfnl_exp *, int, char *);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/link.h
+++ b/include/netlink/cli/link.h
@@ -9,6 +9,10 @@
 #include <netlink/route/link.h>
 #include <netlink/cli/utils.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct rtnl_link *nl_cli_link_alloc(void);
 extern struct nl_cache *nl_cli_link_alloc_cache_family(struct nl_sock *, int);
 extern struct nl_cache *nl_cli_link_alloc_cache_family_flags(struct nl_sock *, int,
@@ -24,5 +28,9 @@ extern void nl_cli_link_parse_ifindex(struct rtnl_link *, char *);
 extern void nl_cli_link_parse_txqlen(struct rtnl_link *, char *);
 extern void nl_cli_link_parse_weight(struct rtnl_link *, char *);
 extern void nl_cli_link_parse_ifalias(struct rtnl_link *, char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/neigh.h
+++ b/include/netlink/cli/neigh.h
@@ -8,6 +8,10 @@
 
 #include <netlink/route/neighbour.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define nl_cli_neigh_alloc_cache(sk) \
 		nl_cli_alloc_cache_flags((sk), "neighbour", NL_CACHE_AF_ITER, \
 					 rtnl_neigh_alloc_cache_flags)
@@ -18,5 +22,9 @@ extern void nl_cli_neigh_parse_lladdr(struct rtnl_neigh *, char *);
 extern void nl_cli_neigh_parse_dev(struct rtnl_neigh *, struct nl_cache *, char *);
 extern void nl_cli_neigh_parse_family(struct rtnl_neigh *, char *);
 extern void nl_cli_neigh_parse_state(struct rtnl_neigh *, char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/qdisc.h
+++ b/include/netlink/cli/qdisc.h
@@ -8,10 +8,18 @@
 
 #include <netlink/route/qdisc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define nl_cli_qdisc_alloc_cache(sk) \
 		nl_cli_alloc_cache((sk), "queueing disciplines", \
 				   rtnl_qdisc_alloc_cache)
 
 extern struct rtnl_qdisc *nl_cli_qdisc_alloc(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/route.h
+++ b/include/netlink/cli/route.h
@@ -8,6 +8,10 @@
 
 #include <netlink/route/route.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct rtnl_route *nl_cli_route_alloc(void);
 
 extern struct nl_cache *nl_cli_route_alloc_cache(struct nl_sock *, int);
@@ -24,5 +28,9 @@ extern void	nl_cli_route_parse_scope(struct rtnl_route *, char *);
 extern void	nl_cli_route_parse_protocol(struct rtnl_route *, char *);
 extern void	nl_cli_route_parse_type(struct rtnl_route *, char *);
 extern void	nl_cli_route_parse_iif(struct rtnl_route *, char *, struct nl_cache *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/rule.h
+++ b/include/netlink/cli/rule.h
@@ -8,8 +8,16 @@
 
 #include <netlink/route/rule.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct rtnl_rule *nl_cli_rule_alloc(void);
 extern struct nl_cache *nl_cli_rule_alloc_cache(struct nl_sock *);
 extern void nl_cli_rule_parse_family(struct rtnl_rule *, char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/netlink/cli/tc.h
+++ b/include/netlink/cli/tc.h
@@ -8,6 +8,10 @@
 
 #include <netlink/route/tc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct rtnl_tc_ops;
 
 extern void nl_cli_tc_parse_dev(struct rtnl_tc *, struct nl_cache *, char *);
@@ -31,5 +35,9 @@ struct nl_cli_tc_module
 extern struct nl_cli_tc_module *nl_cli_tc_lookup(struct rtnl_tc_ops *);
 extern void nl_cli_tc_register(struct nl_cli_tc_module *);
 extern void nl_cli_tc_unregister(struct nl_cli_tc_module *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
cli API has linkage problems as undefined symbols when used in the CPP context.