### PR TITLE
yyerror: update to POSIX standard

### DIFF
--- a/lib/route/cls/ematch_syntax.y
+++ b/lib/route/cls/ematch_syntax.y
@@ -46,6 +46,7 @@
 %{
 extern int ematch_lex(YYSTYPE *, void *);
 
+#define ematch_error yyerror
 static void yyerror(void *scanner, char **errp, struct nl_list_head *root, const char *msg)
 {
 	if (msg)

--- a/lib/route/pktloc_syntax.y
+++ b/lib/route/pktloc_syntax.y
@@ -24,6 +24,7 @@
 %{
 extern int pktloc_lex(YYSTYPE *, YYLTYPE *, void *);
 
+#define pktloc_error yyerror
 static void yyerror(YYLTYPE *locp, void *scanner, const char *msg)
 {
 	NL_DBG(1, "Error while parsing packet location file: %s\n", msg);


### PR DESCRIPTION
To comply with the latest POSIX standard, in Yacc compatibility mode
(options `-y`/`--yacc`) Bison now generates prototypes for yyerror and
yylex.  In some situations, this is breaking compatibility: if the user
has already declared these functions but with some differences (e.g., to
declare them as static, or to use specific attributes), the generated
parser will fail to compile.  To disable these prototypes, #define yyerror
(to `yyerror`), and likewise for yylex.

refer: https://git.savannah.gnu.org/cgit/bison.git/tree/NEWS

GNU Bison 3.8

Issue #294 has the details of the errors