### PR TITLE
zero stack allocated memory in xfrmnl_build_sa_delete_request

### DIFF
--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -1331,6 +1331,7 @@ static int build_xfrm_sa_delete_message(struct xfrmnl_sa *tmpl, int cmd, int fla
 		!(tmpl->ce_mask & XFRM_SA_ATTR_PROTO))
 		return -NLE_MISSING_ATTR;
 
+	memset(&sa_id, 0, sizeof(struct xfrm_usersa_id));
 	memcpy (&sa_id.daddr, nl_addr_get_binary_addr (tmpl->id.daddr),
 	        sizeof (uint8_t) * nl_addr_get_len (tmpl->id.daddr));
 	sa_id.family = nl_addr_get_family (tmpl->id.daddr);


### PR DESCRIPTION
When running valgrind on an application that uses
xfrmnl_build_sa_delete_request, it reports the following error:

==783216== Syscall param sendmsg(msg.msg_iov[0]) points to uninitialised byte(s)
==783216==    at 0x4DF771D: sendmsg (in /usr/lib64/libpthread-2.33.so)
==783216==    by 0x48627D9: nl_sendmsg (nl.c:336)
==783216==    by 0x4862993: nl_send_iovec (nl.c:401)
==783216==    by 0x48629F9: nl_send (nl.c:453)
==783216==    by 0x48629F9: nl_send (nl.c:441)
==783216==    by 0x4931B89: xfrmnl_sa_delete (sa.c:1379)
==783216==    by 0x40A390: delete_associated_state (net-api.c:88)
==783216==    by 0x40C191: del_tunnel (net-api.c:883)
==783216==    by 0x414EB0: net_api_test_tunnel (net-api_test.c:181)
==783216==    by 0x4DD763A: ??? (in /usr/lib64/libcunit.so.1.0.1)
==783216==    by 0x4DD79C0: ??? (in /usr/lib64/libcunit.so.1.0.1)
==783216==    by 0x4DD8966: CU_run_all_tests (in /usr/lib64/libcunit.so.1.0.1)
==783216==    by 0x422E13: RunAllTests (test.c:87)
==783216==    by 0x422FA9: main (test.c:150)
==783216==  Address 0x5217394 is 20 bytes inside a block of size 4,096 alloc'd
==783216==    at 0x4845464: calloc (vg_replace_malloc.c:1117)
==783216==    by 0x4860CF5: __nlmsg_alloc (msg.c:269)
==783216==    by 0x4860FFE: nlmsg_inherit (msg.c:321)
==783216==    by 0x4861091: nlmsg_alloc_simple (msg.c:352)
==783216==    by 0x4931AA5: build_xfrm_sa_delete_message (sa.c:1340)
==783216==    by 0x4931AA5: xfrmnl_sa_build_delete_request (sa.c:1367)
==783216==    by 0x4931B58: xfrmnl_sa_delete (sa.c:1375)
==783216==    by 0x40A390: delete_associated_state (net-api.c:88)
==783216==    by 0x40C191: del_tunnel (net-api.c:883)
==783216==    by 0x414EB0: net_api_test_tunnel (net-api_test.c:181)
==783216==    by 0x4DD763A: ??? (in /usr/lib64/libcunit.so.1.0.1)
==783216==    by 0x4DD79C0: ??? (in /usr/lib64/libcunit.so.1.0.1)
==783216==    by 0x4DD8966: CU_run_all_tests (in /usr/lib64/libcunit.so.1.0.1)
==783216==    by 0x422E13: RunAllTests (test.c:87)
==783216==    by 0x422FA9: main (test.c:150)
==783216==  Uninitialised value was created by a stack allocation
==783216==    at 0x492DA10: ??? (in /home/nhorman/git/privafy/microedge-c/external_libs/install/lib/libnl-xfrm-3.so.200.26.0)

It occurs because the sa_id value thats allocated on the stack isn't
completely initalized (if you're using ipv4, the daddr winds up with
garbage in the extra bytes).  Its not critical, but it would be nice to
avoid sending that garbage into the kernel, and it would silence the
valgrind error.

Easy fix, just memset the sa_id before copying it into the nlmsg.

Signed-off-by: Neil Horman <nhorman@gmail.com>