### PR TITLE
[th/object-clone-fixes]

### DIFF
--- a/include/netlink-private/netlink.h
+++ b/include/netlink-private/netlink.h
@@ -59,6 +59,7 @@
 #include <netlink-private/object-api.h>
 #include <netlink-private/cache-api.h>
 #include <netlink-private/types.h>
+#include <netlink-private/utils.h>
 
 #define NSEC_PER_SEC	1000000000L
 

--- a/include/netlink-private/route/link/api.h
+++ b/include/netlink-private/route/link/api.h
@@ -62,6 +62,7 @@ struct rtnl_link_info_ops
 };
 
 extern struct rtnl_link_info_ops *rtnl_link_info_ops_lookup(const char *);
+extern void			rtnl_link_info_ops_get(struct rtnl_link_info_ops *);
 extern void			rtnl_link_info_ops_put(struct rtnl_link_info_ops *);
 extern int			rtnl_link_register_info(struct rtnl_link_info_ops *);
 extern int			rtnl_link_unregister_info(struct rtnl_link_info_ops *);

--- a/include/netlink-private/utils.h
+++ b/include/netlink-private/utils.h
@@ -280,4 +280,24 @@ _nl_close(int fd)
 	return r;
 }
 
+static inline void *
+_nl_memdup(const void *ptr, size_t len)
+{
+	void *p;
+
+	if (len == 0) {
+		/* malloc() leaves it implementation defined whether to return NULL.
+		 * Callers rely on returning NULL if len is zero. */
+		return NULL;
+	}
+
+	p = malloc(len);
+	if (!p)
+		return NULL;
+	memcpy(p, ptr, len);
+	return p;
+}
+
+#define _nl_memdup_ptr(ptr) ((__typeof__(ptr)) _nl_memdup((ptr), sizeof(*(ptr))))
+
 #endif

--- a/lib/fib_lookup/lookup.c
+++ b/lib/fib_lookup/lookup.c
@@ -55,11 +55,13 @@ static int result_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct flnl_result *dst = nl_object_priv(_dst);
 	struct flnl_result *src = nl_object_priv(_src);
 
-	if (src->fr_req)
-		if (!(dst->fr_req = (struct flnl_request *)
-				nl_object_clone(OBJ_CAST(src->fr_req))))
+	dst->fr_req = NULL;
+
+	if (src->fr_req) {
+		if (!(dst->fr_req = (struct flnl_request *) nl_object_clone(OBJ_CAST(src->fr_req))))
 			return -NLE_NOMEM;
-	
+	}
+
 	return 0;
 }
 

--- a/lib/fib_lookup/request.c
+++ b/lib/fib_lookup/request.c
@@ -40,9 +40,12 @@ static int request_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct flnl_request *dst = nl_object_priv(_dst);
 	struct flnl_request *src = nl_object_priv(_src);
 
-	if (src->lr_addr)
+	dst->lr_addr = NULL;
+
+	if (src->lr_addr) {
 		if (!(dst->lr_addr = nl_addr_clone(src->lr_addr)))
 			return -NLE_NOMEM;
+	}
 
 	return 0;
 }

--- a/lib/genl/family.c
+++ b/lib/genl/family.c
@@ -67,6 +67,9 @@ static int family_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct genl_family_grp *grp;
 	int err;
 
+	nl_init_list_head(&dst->gf_ops);
+	nl_init_list_head(&dst->gf_mc_grps);
+
 	nl_list_for_each_entry(ops, &src->gf_ops, o_list) {
 		err = genl_family_add_op(dst, ops->o_id, ops->o_flags);
 		if (err < 0)

--- a/lib/idiag/idiag_msg_obj.c
+++ b/lib/idiag/idiag_msg_obj.c
@@ -622,9 +622,9 @@ static int idiagnl_msg_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct idiagnl_msg *dst = (struct idiagnl_msg *) _dst;
 	struct idiagnl_msg *src = (struct idiagnl_msg *) _src;
 
-	dst->idiag_cong = NULL;
 	dst->idiag_src = NULL;
 	dst->idiag_dst = NULL;
+	dst->idiag_cong = NULL;
 	dst->idiag_meminfo = NULL;
 	dst->idiag_vegasinfo = NULL;
 	dst->ce_mask &= ~(IDIAGNL_ATTR_CONG |

--- a/lib/idiag/idiag_req_obj.c
+++ b/lib/idiag/idiag_req_obj.c
@@ -169,6 +169,9 @@ static int idiagnl_req_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct idiagnl_req *dst = (struct idiagnl_req *) _dst;
 	struct idiagnl_req *src = (struct idiagnl_req *) _src;
 
+	src->idiag_src = NULL;
+	src->idiag_dst = NULL;
+
 	if (src->idiag_src)
 		if (!(dst->idiag_src = nl_addr_clone(src->idiag_src)))
 			return -NLE_NOMEM;

--- a/lib/netfilter/ct_obj.c
+++ b/lib/netfilter/ct_obj.c
@@ -68,6 +68,11 @@ static int ct_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct nfnl_ct *src = (struct nfnl_ct *) _src;
 	struct nl_addr *addr;
 
+	dst->ct_orig.src = NULL;
+	dst->ct_orig.dst = NULL;
+	dst->ct_repl.src = NULL;
+	dst->ct_repl.dst = NULL;
+
 	if (src->ct_orig.src) {
 		addr = nl_addr_clone(src->ct_orig.src);
 		if (!addr)

--- a/lib/netfilter/exp_obj.c
+++ b/lib/netfilter/exp_obj.c
@@ -81,7 +81,17 @@ static int exp_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct nfnl_exp *src = (struct nfnl_exp *) _src;
 	struct nl_addr *addr;
 
-	// Expectation
+	dst->exp_helper_name = NULL;
+	dst->exp_fn = NULL;
+	dst->exp_expect.src = NULL;
+	dst->exp_expect.dst = NULL;
+	dst->exp_master.src = NULL;
+	dst->exp_master.dst = NULL;
+	dst->exp_mask.src = NULL;
+	dst->exp_mask.dst = NULL;
+	dst->exp_nat.src = NULL;
+	dst->exp_nat.dst = NULL;
+
 	if (src->exp_expect.src) {
 		addr = nl_addr_clone(src->exp_expect.src);
 		if (!addr)
@@ -96,7 +106,6 @@ static int exp_clone(struct nl_object *_dst, struct nl_object *_src)
 		dst->exp_expect.dst = addr;
 	}
 
-	// Master CT
 	if (src->exp_master.src) {
 		addr = nl_addr_clone(src->exp_master.src);
 		if (!addr)
@@ -111,7 +120,6 @@ static int exp_clone(struct nl_object *_dst, struct nl_object *_src)
 		dst->exp_master.dst = addr;
 	}
 
-	// Mask
 	if (src->exp_mask.src) {
 		addr = nl_addr_clone(src->exp_mask.src);
 		if (!addr)
@@ -126,7 +134,6 @@ static int exp_clone(struct nl_object *_dst, struct nl_object *_src)
 		dst->exp_mask.dst = addr;
 	}
 
-	// NAT
 	if (src->exp_nat.src) {
 		addr = nl_addr_clone(src->exp_nat.src);
 		if (!addr)

--- a/lib/netfilter/log_msg_obj.c
+++ b/lib/netfilter/log_msg_obj.c
@@ -387,14 +387,22 @@ const uint8_t *nfnl_log_msg_get_hwaddr(const struct nfnl_log_msg *msg, int *len)
 
 int nfnl_log_msg_set_payload(struct nfnl_log_msg *msg, uint8_t *payload, int len)
 {
-	free(msg->log_msg_payload);
-	msg->log_msg_payload = malloc(len);
-	if (!msg->log_msg_payload)
+	uint8_t *p = NULL;
+
+	if (len < 0)
+		return -NLE_INVAL;
+
+	p = _nl_memdup(payload, len);
+	if (!p && len > 0)
 		return -NLE_NOMEM;
 
-	memcpy(msg->log_msg_payload, payload, len);
+	free(msg->log_msg_payload);
+	msg->log_msg_payload = p;
 	msg->log_msg_payload_len = len;
-	msg->ce_mask |= LOG_MSG_ATTR_PAYLOAD;
+	if (len > 0)
+		msg->ce_mask |= LOG_MSG_ATTR_PAYLOAD;
+	else
+		msg->ce_mask &= ~LOG_MSG_ATTR_PAYLOAD;
 	return 0;
 }
 
@@ -411,12 +419,21 @@ const void *nfnl_log_msg_get_payload(const struct nfnl_log_msg *msg, int *len)
 
 int nfnl_log_msg_set_prefix(struct nfnl_log_msg *msg, void *prefix)
 {
-	free(msg->log_msg_prefix);
-	msg->log_msg_prefix = strdup(prefix);
-	if (!msg->log_msg_prefix)
-		return -NLE_NOMEM;
+	char *p = NULL;
 
-	msg->ce_mask |= LOG_MSG_ATTR_PREFIX;
+	if (prefix) {
+		p = strdup(prefix);
+		if (!p)
+			return -NLE_NOMEM;
+	}
+
+	free(msg->log_msg_prefix);
+	msg->log_msg_prefix = p;
+
+	if (p)
+		msg->ce_mask |= LOG_MSG_ATTR_PREFIX;
+	else
+		msg->ce_mask &= ~LOG_MSG_ATTR_PREFIX;
 	return 0;
 }
 
@@ -524,14 +541,22 @@ uint16_t nfnl_log_msg_get_hwlen(const struct nfnl_log_msg *msg)
 
 int nfnl_log_msg_set_hwheader(struct nfnl_log_msg *msg, void *data, int len)
 {
-	free(msg->log_msg_hwheader);
-	msg->log_msg_hwheader = malloc(len);
-	if (!msg->log_msg_hwheader)
+	void *p = NULL;
+
+	if (len < 0)
+		return -NLE_INVAL;
+
+	p = _nl_memdup(data, len);
+	if (!p && len > 0)
 		return -NLE_NOMEM;
 
-	memcpy(msg->log_msg_hwheader, data, len);
+	free(msg->log_msg_hwheader);
+	msg->log_msg_hwheader = p;
 	msg->log_msg_hwheader_len = len;
-	msg->ce_mask |= LOG_MSG_ATTR_HWHEADER;
+	if (len > 0)
+		msg->ce_mask |= LOG_MSG_ATTR_HWHEADER;
+	else
+		msg->ce_mask &= ~LOG_MSG_ATTR_HWHEADER;
 	return 0;
 }
 

--- a/lib/netfilter/log_msg_obj.c
+++ b/lib/netfilter/log_msg_obj.c
@@ -56,37 +56,41 @@ static int log_msg_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct nfnl_log_msg *src = (struct nfnl_log_msg *) _src;
 	int err;
 
+	dst->log_msg_payload = NULL;
+	dst->log_msg_payload_len = 0;
+	dst->log_msg_prefix = NULL;
+	dst->log_msg_hwheader = NULL;
+	dst->log_msg_hwheader_len = 0;
+	dst->log_msg_ct = NULL;
+
 	if (src->log_msg_payload) {
 		err = nfnl_log_msg_set_payload(dst, src->log_msg_payload,
-					       src->log_msg_payload_len);
+		                               src->log_msg_payload_len);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	if (src->log_msg_prefix) {
 		err = nfnl_log_msg_set_prefix(dst, src->log_msg_prefix);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	if (src->log_msg_hwheader) {
 		err = nfnl_log_msg_set_hwheader(dst, src->log_msg_hwheader,
 		                                src->log_msg_hwheader_len);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	if (src->log_msg_ct) {
 		dst->log_msg_ct = (struct nfnl_ct *) nl_object_clone((struct nl_object *) src->log_msg_ct);
 		if (!dst->log_msg_ct) {
-			err = -NLE_NOMEM;
-			goto errout;
+			return -NLE_NOMEM;
 		}
 	}
 
 	return 0;
-errout:
-	return err;
 }
 
 static void log_msg_dump(struct nl_object *a, struct nl_dump_params *p)

--- a/lib/netfilter/queue_msg_obj.c
+++ b/lib/netfilter/queue_msg_obj.c
@@ -385,7 +385,7 @@ int nfnl_queue_msg_test_hwaddr(const struct nfnl_queue_msg *msg)
 }
 
 const uint8_t *nfnl_queue_msg_get_hwaddr(const struct nfnl_queue_msg *msg,
-					 int *len)
+                                         int *len)
 {
 	if (!(msg->ce_mask & QUEUE_MSG_ATTR_HWADDR)) {
 		*len = 0;
@@ -397,19 +397,24 @@ const uint8_t *nfnl_queue_msg_get_hwaddr(const struct nfnl_queue_msg *msg,
 }
 
 int nfnl_queue_msg_set_payload(struct nfnl_queue_msg *msg, uint8_t *payload,
-			       int len)
+                               int len)
 {
-	void *new_payload = malloc(len);
+	void *p = NULL;
 
-	if (new_payload == NULL)
+	if (len < 0)
+		return -NLE_INVAL;
+
+	p = _nl_memdup(payload, len);
+	if (!p && len > 0)
 		return -NLE_NOMEM;
-	memcpy(new_payload, payload, len);
 
 	free(msg->queue_msg_payload);
-
-	msg->queue_msg_payload = new_payload;
+	msg->queue_msg_payload = p;
 	msg->queue_msg_payload_len = len;
-	msg->ce_mask |= QUEUE_MSG_ATTR_PAYLOAD;
+	if (len > 0)
+		msg->ce_mask |= QUEUE_MSG_ATTR_PAYLOAD;
+	else
+		msg->ce_mask &= ~QUEUE_MSG_ATTR_PAYLOAD;
 	return 0;
 }
 

--- a/lib/netfilter/queue_msg_obj.c
+++ b/lib/netfilter/queue_msg_obj.c
@@ -42,16 +42,17 @@ static int nfnl_queue_msg_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct nfnl_queue_msg *src = (struct nfnl_queue_msg *) _src;
 	int err;
 
+	dst->queue_msg_payload = NULL;
+	dst->queue_msg_payload_len = 0;
+
 	if (src->queue_msg_payload) {
 		err = nfnl_queue_msg_set_payload(dst, src->queue_msg_payload,
-						 src->queue_msg_payload_len);
+		                                 src->queue_msg_payload_len);
 		if (err < 0)
-			goto errout;
+			return err;
 	}
 
 	return 0;
-errout:
-	return err;
 }
 
 static void nfnl_queue_msg_dump(struct nl_object *a, struct nl_dump_params *p)

--- a/lib/object.c
+++ b/lib/object.c
@@ -127,6 +127,11 @@ struct nl_object *nl_object_clone(struct nl_object *obj)
 	if (size)
 		memcpy((char *)new + doff, (char *)obj + doff, size);
 
+	/* Note that the base implementation already initializes @new via memcpy().
+	 * That means, simple fields don't need to be handled via oo_clone().
+	 * However, this is only a shallow-copy, so oo_clone() MUST fix all
+	 * pointer values accordingly. */
+
 	if (ops->oo_clone) {
 		if (ops->oo_clone(new, obj) < 0) {
 			nl_object_free(new);

--- a/lib/route/addr.c
+++ b/lib/route/addr.c
@@ -153,6 +153,13 @@ static int addr_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct rtnl_addr *dst = nl_object_priv(_dst);
 	struct rtnl_addr *src = nl_object_priv(_src);
 
+	dst->a_peer = NULL;
+	dst->a_local = NULL;
+	dst->a_bcast = NULL;
+	dst->a_anycast = NULL;
+	dst->a_multicast = NULL;
+	dst->a_link = NULL;
+
 	if (src->a_link) {
 		nl_object_get(OBJ_CAST(src->a_link));
 		dst->a_link = src->a_link;
@@ -161,7 +168,7 @@ static int addr_clone(struct nl_object *_dst, struct nl_object *_src)
 	if (src->a_peer)
 		if (!(dst->a_peer = nl_addr_clone(src->a_peer)))
 			return -NLE_NOMEM;
-	
+
 	if (src->a_local)
 		if (!(dst->a_local = nl_addr_clone(src->a_local)))
 			return -NLE_NOMEM;

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -286,6 +286,19 @@ static int link_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct rtnl_link *src = nl_object_priv(_src);
 	int err;
 
+	dst->l_addr = NULL;
+	dst->l_bcast = NULL;
+	dst->l_info_kind = NULL;
+	dst->l_info_slave_kind = NULL;
+	dst->l_info_ops = NULL;
+	memset(dst->l_af_data, 0, sizeof (dst->l_af_data));
+	dst->l_info = NULL;
+	dst->l_ifalias = NULL;
+	dst->l_af_ops = NULL;
+	dst->l_phys_port_id = NULL;
+	dst->l_phys_switch_id = NULL;
+	dst->l_vf_list = NULL;
+
 	if (src->l_addr)
 		if (!(dst->l_addr = nl_addr_clone(src->l_addr)))
 			return -NLE_NOMEM;

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -306,10 +306,16 @@ static int link_clone(struct nl_object *_dst, struct nl_object *_src)
 		if (!(dst->l_info_slave_kind = strdup(src->l_info_slave_kind)))
 			return -NLE_NOMEM;
 
-	if (src->l_info_ops && src->l_info_ops->io_clone) {
-		err = src->l_info_ops->io_clone(dst, src);
-		if (err < 0)
-			return err;
+	if (src->l_info_ops) {
+
+		rtnl_link_info_ops_get(src->l_info_ops);
+		dst->l_info_ops = src->l_info_ops;
+
+		if (src->l_info_ops->io_clone) {
+			err = src->l_info_ops->io_clone(dst, src);
+			if (err < 0)
+				return err;
+		}
 	}
 
 	if ((err = do_foreach_af(src, af_clone, dst)) < 0)

--- a/lib/route/link/api.c
+++ b/lib/route/link/api.c
@@ -81,13 +81,31 @@ struct rtnl_link_info_ops *rtnl_link_info_ops_lookup(const char *name)
 }
 
 /**
+ * Take reference to a set of operations.
+ * @arg ops		Link info operations.
+ */
+void rtnl_link_info_ops_get(struct rtnl_link_info_ops *ops)
+{
+	if (!ops)
+		return;
+
+	nl_write_lock(&info_lock);
+	ops->io_refcnt++;
+	nl_write_unlock(&info_lock);
+}
+
+/**
  * Give back reference to a set of operations.
  * @arg ops		Link info operations.
  */
 void rtnl_link_info_ops_put(struct rtnl_link_info_ops *ops)
 {
-	if (ops)
-		ops->io_refcnt--;
+	if (!ops)
+		return;
+
+	nl_write_lock(&info_lock);
+	ops->io_refcnt--;
+	nl_write_unlock(&info_lock);
 }
 
 /**

--- a/lib/route/mdb.c
+++ b/lib/route/mdb.c
@@ -108,6 +108,7 @@ static int mdb_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct rtnl_mdb_entry *entry;
 
 	nl_init_list_head(&dst->mdb_entry_list);
+
 	nl_list_for_each_entry(entry, &src->mdb_entry_list, mdb_list) {
 		struct rtnl_mdb_entry *copy = mdb_entry_clone(entry);
 

--- a/lib/route/neigh.c
+++ b/lib/route/neigh.c
@@ -185,6 +185,9 @@ static int neigh_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct rtnl_neigh *dst = nl_object_priv(_dst);
 	struct rtnl_neigh *src = nl_object_priv(_src);
 
+	dst->n_lladdr = NULL;
+	dst->n_dst = NULL;
+
 	if (src->n_lladdr)
 		if (!(dst->n_lladdr = nl_addr_clone(src->n_lladdr)))
 			return -NLE_NOMEM;

--- a/lib/route/netconf.c
+++ b/lib/route/netconf.c
@@ -74,16 +74,6 @@ static struct rtnl_netconf *rtnl_netconf_alloc(void)
 	return (struct rtnl_netconf *) nl_object_alloc(&netconf_obj_ops);
 }
 
-static int netconf_clone(struct nl_object *_dst, struct nl_object *_src)
-{
-	struct rtnl_netconf *dst = nl_object_priv(_dst);
-	struct rtnl_netconf *src = nl_object_priv(_src);
-
-	*dst = *src;
-
-	return 0;
-}
-
 static int netconf_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
 			      struct nlmsghdr *nlh, struct nl_parser_param *pp)
 {
@@ -528,7 +518,6 @@ int rtnl_netconf_get_input(struct rtnl_netconf *nc, int *val)
 static struct nl_object_ops netconf_obj_ops = {
 	.oo_name		= "route/netconf",
 	.oo_size		= sizeof(struct rtnl_netconf),
-	.oo_clone		= netconf_clone,
 	.oo_dump = {
 	    [NL_DUMP_LINE] 	= netconf_dump_line,
 	    [NL_DUMP_DETAILS] 	= netconf_dump_line,

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -98,22 +98,27 @@ static int route_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct rtnl_route *src = (struct rtnl_route *) _src;
 	struct rtnl_nexthop *nh, *new;
 
-	if (src->rt_dst)
-		if (!(dst->rt_dst = nl_addr_clone(src->rt_dst)))
-			return -NLE_NOMEM;
-
-	if (src->rt_src)
-		if (!(dst->rt_src = nl_addr_clone(src->rt_src)))
-			return -NLE_NOMEM;
-
-	if (src->rt_pref_src)
-		if (!(dst->rt_pref_src = nl_addr_clone(src->rt_pref_src)))
-			return -NLE_NOMEM;
-
-	/* Will be inc'ed again while adding the nexthops of the source */
+	dst->rt_dst = NULL;
+	dst->rt_src = NULL;
+	dst->rt_pref_src = NULL;
+	nl_init_list_head(&dst->rt_nexthops);
 	dst->rt_nr_nh = 0;
 
-	nl_init_list_head(&dst->rt_nexthops);
+	if (src->rt_dst) {
+		if (!(dst->rt_dst = nl_addr_clone(src->rt_dst)))
+			return -NLE_NOMEM;
+	}
+
+	if (src->rt_src) {
+		if (!(dst->rt_src = nl_addr_clone(src->rt_src)))
+			return -NLE_NOMEM;
+	}
+
+	if (src->rt_pref_src) {
+		if (!(dst->rt_pref_src = nl_addr_clone(src->rt_pref_src)))
+			return -NLE_NOMEM;
+	}
+
 	nl_list_for_each_entry(nh, &src->rt_nexthops, rtnh_list) {
 		new = rtnl_route_nh_clone(nh);
 		if (!new)

--- a/lib/route/rule.c
+++ b/lib/route/rule.c
@@ -59,6 +59,9 @@ static int rule_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct rtnl_rule *dst = nl_object_priv(_dst);
 	struct rtnl_rule *src = nl_object_priv(_src);
 
+	dst->r_src = NULL;
+	dst->r_dst = NULL;
+
 	if (src->r_src)
 		if (!(dst->r_src = nl_addr_clone(src->r_src)))
 			return -NLE_NOMEM;

--- a/lib/route/tc.c
+++ b/lib/route/tc.c
@@ -808,14 +808,17 @@ int rtnl_tc_clone(struct nl_object *dstobj, struct nl_object *srcobj)
 	struct rtnl_tc *src = TC_CAST(srcobj);
 	struct rtnl_tc_ops *ops;
 
+	dst->tc_opts = NULL;
+	dst->tc_xstats = NULL;
+	dst->tc_subdata = NULL;
+	dst->tc_link = NULL;
+	dst->tc_ops = NULL;
+
 	if (src->tc_link) {
 		nl_object_get(OBJ_CAST(src->tc_link));
 		dst->tc_link = src->tc_link;
 	}
 
-	dst->tc_opts = NULL;
-	dst->tc_xstats = NULL;
-	dst->tc_subdata = NULL;
 	dst->ce_mask &= ~(TCA_ATTR_OPTS |
 	                  TCA_ATTR_XSTATS);
 
@@ -841,7 +844,10 @@ int rtnl_tc_clone(struct nl_object *dstobj, struct nl_object *srcobj)
 		/* Warning: if the data contains pointer, then at this point, dst->tc_subdata
 		 * will alias those pointers.
 		 *
-		 * ops->to_clone() MUST fix that. */
+		 * ops->to_clone() MUST fix that.
+		 *
+		 * If the type is actually "struct rtnl_act", then to_clone() must also
+		 * fix dangling "a_next" pointer. */
 
 		ops = rtnl_tc_get_ops(src);
 		if (ops && ops->to_clone) {

--- a/lib/xfrm/ae.c
+++ b/lib/xfrm/ae.c
@@ -164,17 +164,23 @@ static int xfrm_ae_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct xfrmnl_ae* dst = nl_object_priv(_dst);
 	struct xfrmnl_ae* src = nl_object_priv(_src);
 
-	if (src->sa_id.daddr)
+	dst->sa_id.daddr = NULL;
+	dst->saddr = NULL;
+	dst->replay_state_esn = NULL;
+
+	if (src->sa_id.daddr) {
 		if ((dst->sa_id.daddr = nl_addr_clone (src->sa_id.daddr)) == NULL)
 			return -NLE_NOMEM;
+	}
 
-	if (src->saddr)
+	if (src->saddr) {
 		if ((dst->saddr = nl_addr_clone (src->saddr)) == NULL)
 			return -NLE_NOMEM;
+	}
 
-	if (src->replay_state_esn)
-	{
+	if (src->replay_state_esn) {
 		uint32_t len = sizeof (struct xfrmnl_replay_state_esn) + (sizeof (uint32_t) * src->replay_state_esn->bmp_len);
+
 		if ((dst->replay_state_esn = malloc (len)) == NULL)
 			return -NLE_NOMEM;
 		memcpy (dst->replay_state_esn, src->replay_state_esn, len);

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -205,6 +205,12 @@ static int xfrm_sa_clone(struct nl_object *_dst, struct nl_object *_src)
 		memcpy ((void *)dst->replay_state_esn, (void *)src->replay_state_esn, len);
 	}
 
+	if (src->user_offload) {
+		dst->user_offload = _nl_memdup_ptr(src->user_offload);
+		if (!dst->user_offload)
+			return -NLE_NOMEM;
+	}
+
 	return 0;
 }
 

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -136,6 +136,20 @@ static int xfrm_sa_clone(struct nl_object *_dst, struct nl_object *_src)
 	struct xfrmnl_sa*   src = nl_object_priv(_src);
 	uint32_t            len = 0;
 
+	dst->sel = NULL;
+	dst->id.daddr = NULL;
+	dst->saddr = NULL;
+	dst->lft = NULL;
+	dst->aead = NULL;
+	dst->auth = NULL;
+	dst->crypt = NULL;
+	dst->comp = NULL;
+	dst->encap = NULL;
+	dst->coaddr = NULL;
+	dst->sec_ctx = NULL;
+	dst->replay_state_esn = NULL;
+	dst->user_offload = NULL;
+
 	if (src->sel)
 		if ((dst->sel = xfrmnl_sel_clone (src->sel)) == NULL)
 			return -NLE_NOMEM;

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -152,40 +152,35 @@ static int xfrm_sa_clone(struct nl_object *_dst, struct nl_object *_src)
 		if ((dst->saddr = nl_addr_clone (src->saddr)) == NULL)
 			return -NLE_NOMEM;
 
-	if (src->aead)
-	{
+	if (src->aead) {
 		len = sizeof (struct xfrmnl_algo_aead) + ((src->aead->alg_key_len + 7) / 8);
 		if ((dst->aead = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;
 		memcpy ((void *)dst->aead, (void *)src->aead, len);
 	}
 
-	if (src->auth)
-	{
+	if (src->auth) {
 		len = sizeof (struct xfrmnl_algo_auth) + ((src->auth->alg_key_len + 7) / 8);
 		if ((dst->auth = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;
 		memcpy ((void *)dst->auth, (void *)src->auth, len);
 	}
 
-	if (src->crypt)
-	{
+	if (src->crypt) {
 		len = sizeof (struct xfrmnl_algo) + ((src->crypt->alg_key_len + 7) / 8);
 		if ((dst->crypt = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;
 		memcpy ((void *)dst->crypt, (void *)src->crypt, len);
 	}
 
-	if (src->comp)
-	{
+	if (src->comp) {
 		len = sizeof (struct xfrmnl_algo) + ((src->comp->alg_key_len + 7) / 8);
 		if ((dst->comp = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;
 		memcpy ((void *)dst->comp, (void *)src->comp, len);
 	}
 
-	if (src->encap)
-	{
+	if (src->encap) {
 		len = sizeof (struct xfrmnl_encap_tmpl);
 		if ((dst->encap = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;
@@ -196,16 +191,14 @@ static int xfrm_sa_clone(struct nl_object *_dst, struct nl_object *_src)
 		if ((dst->coaddr = nl_addr_clone (src->coaddr)) == NULL)
 			return -NLE_NOMEM;
 
-	if (src->sec_ctx)
-	{
+	if (src->sec_ctx) {
 		len = sizeof (*src->sec_ctx) + src->sec_ctx->ctx_len;
 		if ((dst->sec_ctx = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;
 		memcpy ((void *)dst->sec_ctx, (void *)src->sec_ctx, len);
 	}
 
-	if (src->replay_state_esn)
-	{
+	if (src->replay_state_esn) {
 		len = sizeof (struct xfrmnl_replay_state_esn) + (src->replay_state_esn->bmp_len * sizeof (uint32_t));
 		if ((dst->replay_state_esn = calloc (1, len)) == NULL)
 			return -NLE_NOMEM;

--- a/libnl-3.sym
+++ b/libnl-3.sym
@@ -363,3 +363,8 @@ libnl_3_5 {
 global:
 	nla_nest_end_keep_empty;
 } libnl_3_2_29;
+
+libnl_3_6 {
+global:
+	rtnl_link_info_ops_get;
+} libnl_3_5;


### PR DESCRIPTION
various fixes. In particular, fix `nl_object_clone()` in ENOMEM situations.