### PR TITLE
route/link: add VLAN bridge binding flag

### DIFF
--- a/include/linux-private/linux/if_vlan.h
+++ b/include/linux-private/linux/if_vlan.h
@@ -32,10 +32,11 @@ enum vlan_ioctl_cmds {
 };
 
 enum vlan_flags {
-	VLAN_FLAG_REORDER_HDR	= 0x1,
-	VLAN_FLAG_GVRP		= 0x2,
-	VLAN_FLAG_LOOSE_BINDING	= 0x4,
-	VLAN_FLAG_MVRP		= 0x8,
+	VLAN_FLAG_REORDER_HDR		= 0x1,
+	VLAN_FLAG_GVRP			= 0x2,
+	VLAN_FLAG_LOOSE_BINDING		= 0x4,
+	VLAN_FLAG_MVRP			= 0x8,
+	VLAN_FLAG_BRIDGE_BINDING	= 0x10,
 };
 
 enum vlan_name_types {

--- a/lib/route/link/vlan.c
+++ b/lib/route/link/vlan.c
@@ -641,6 +641,7 @@ static const struct trans_tbl vlan_flags[] = {
 	__ADD(VLAN_FLAG_GVRP, gvrp),
 	__ADD(VLAN_FLAG_LOOSE_BINDING, loose_binding),
 	__ADD(VLAN_FLAG_MVRP, mvrp),
+	__ADD(VLAN_FLAG_BRIDGE_BINDING, bridge_binding),
 };
 
 /**


### PR DESCRIPTION
Adds support for the new VLAN_FLAG_BRIDGE_BINDING, for VLAN interfaces
created on top of a VLAN aware bridge.  For details, see the kernel
patch:

https://lore.kernel.org/netdev/20190418173535.22925-1-mmanning@vyatta.att-mail.com/

Signed-off-by: Joachim Wiberg <troglobit@gmail.com>