### PR TITLE
Check validation type against end of enum

### DIFF
--- a/lib/route/link/macsec.c
+++ b/lib/route/link/macsec.c
@@ -708,7 +708,7 @@ int rtnl_link_macsec_set_validation_type(struct rtnl_link *link, enum macsec_val
 
 	IS_MACSEC_LINK_ASSERT(link);
 
-	if (validate > 1)
+	if (validate > MACSEC_VALIDATE_MAX)
 		return -NLE_INVAL;
 
 	info->validate = validate;


### PR DESCRIPTION
The enum macsec_validation_type in the Linux Kernel has values 0-2.
With the existing check >1, value STRICT (2) cannot be set.
The check should be done against the end marker of the enum instead.