### PR TITLE
route/mdb: fixes to dumping, support for multicast mac entries, minor fixes to nl-monitor

### DIFF
--- a/include/linux-private/linux/if_bridge.h
+++ b/include/linux-private/linux/if_bridge.h
@@ -243,6 +243,7 @@ struct br_mdb_entry {
 		union {
 			__be32	ip4;
 			struct in6_addr ip6;
+			unsigned char mac_addr[ETH_ALEN];
 		} u;
 		__be16		proto;
 	} addr;

--- a/lib/route/mdb.c
+++ b/lib/route/mdb.c
@@ -277,6 +277,16 @@ static void mdb_dump_line(struct nl_object *obj, struct nl_dump_params *p)
 	}
 }
 
+static void mdb_dump_details(struct nl_object *obj, struct nl_dump_params *p)
+{
+	mdb_dump_line(obj, p);
+}
+
+static void mdb_dump_stats(struct nl_object *obj, struct nl_dump_params *p)
+{
+	mdb_dump_details(obj, p);
+}
+
 void rtnl_mdb_put(struct rtnl_mdb *mdb)
 {
 	nl_object_put((struct nl_object *) mdb);
@@ -384,8 +394,10 @@ static struct nl_object_ops mdb_obj_ops = {
 	.oo_size = sizeof(struct rtnl_mdb),
 	.oo_constructor = mdb_constructor,
 	.oo_dump = {
-	            [NL_DUMP_LINE] = mdb_dump_line,
-	           },
+	            [NL_DUMP_LINE]    = mdb_dump_line,
+	            [NL_DUMP_DETAILS] = mdb_dump_details,
+	            [NL_DUMP_STATS]   = mdb_dump_stats,
+	},
 	.oo_clone = mdb_clone,
 	.oo_compare = mdb_compare,
 	.oo_update = mdb_update,

--- a/lib/route/mdb.c
+++ b/lib/route/mdb.c
@@ -232,7 +232,12 @@ static int mdb_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
 					entry->addr = nl_addr_build(AF_INET6,
 					                            &e->addr.u.ip6,
 					                            sizeof(e->addr.u.ip6));
+				} else {
+					entry->addr = nl_addr_build(AF_LLC,
+								    e->addr.u.mac_addr,
+								    sizeof(e->addr.u.mac_addr));
 				}
+
 				if (!entry->addr)
 					goto errout;
 

--- a/src/nl-monitor.c
+++ b/src/nl-monitor.c
@@ -87,6 +87,7 @@ int main(int argc, char *argv[])
 		int c, optidx = 0;
 		static struct option long_opts[] = {
 			{ "format", 1, 0, 'f' },
+			{ "help",   0, 0, 'h' },
 			{ 0, 0, 0, 0 }
 		};
 

--- a/src/nl-monitor.c
+++ b/src/nl-monitor.c
@@ -56,6 +56,7 @@ static void print_usage(void)
 	"Usage: nl-monitor [OPTION] [<groups>]\n"
 	"\n"
 	"Options\n"
+	" -d, --debug=LEVEL     Set libnl debug level { 0 - 7 }\n"
 	" -f, --format=TYPE     Output format { brief | details | stats }\n"
 	" -h, --help            Show this help.\n"
 	"\n"
@@ -86,16 +87,20 @@ int main(int argc, char *argv[])
 	for (;;) {
 		int c, optidx = 0;
 		static struct option long_opts[] = {
+			{ "debug",  1, 0, 'd' },
 			{ "format", 1, 0, 'f' },
 			{ "help",   0, 0, 'h' },
 			{ 0, 0, 0, 0 }
 		};
 
-		c = getopt_long(argc, argv, "f:h", long_opts, &optidx);
+		c = getopt_long(argc, argv, "d:f:h", long_opts, &optidx);
 		if (c == -1)
                         break;
 
                 switch (c) {
+		case 'd':
+			nl_debug = atoi(optarg);
+			break;
                 case 'f':
 			dp.dp_type = nl_cli_parse_dumptype(optarg);
 			break;


### PR DESCRIPTION
This is a mixed bag of fixes related to debugging the bridge mdb support.

 1. Minor fixes and additions to `nl-monitor`, used to debug mdb system
 2. Add missing details mdb dump callback 
 3. Add support for MAC multicast entries

With this series applied, on a system with a bridge set up with at least one port:

    # nl-monitor mdb &
    # bridge mdb add dev br0 port eth0 grp 01:02:03:c0:ff:ee vid 1 permanent
    dev 9
    port 3 vid 1 proto 0x0000 address 01:02:03:c0:ff:ee
