### PR TITLE
route/link: Remove reset of cache ops when cloning a link

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -334,6 +334,9 @@ static int link_clone(struct nl_object *_dst, struct nl_object *_src)
 	if ((err = do_foreach_af(src, af_clone, dst)) < 0)
 		return err;
 
+	if (src->l_af_ops)
+		dst->l_af_ops = af_lookup_and_alloc(dst, src->l_af_ops->ao_family);
+
 	if (src->l_phys_port_id)
 		if (!(dst->l_phys_port_id = nl_data_clone(src->l_phys_port_id)))
 			return -NLE_NOMEM;


### PR DESCRIPTION
We are running in to problems with working with a cloned link cache. We are more or less doing:

```
rtnl_link_alloc_cache(sk, AF_BRIDGE, &cache);
new = nl_cache_clone(cache);

link = ...some link fetched from new
rtnl_link_is_bridge(link);  /* Will always return 0 since link_clone has set link->l_af_ops = NULL */
```

As mentioned `rtnl_link_is_bridge` will return 0 even for links that are bridges, since link_clone remove the cache_ops when the cache was cloned.
