### PR TITLE
lib: handle default route destinations in nla_put_addr()

### DIFF
--- a/lib/addr.c
+++ b/lib/addr.c
@@ -325,14 +325,17 @@ int nl_addr_parse(const char *addrstr, int hint, struct nl_addr **result)
 				 * no hint given the user wants to have a IPv4
 				 * address given back. */
 				family = AF_INET;
+				len = 4;
 				goto prefix;
 
 			case AF_INET6:
 				family = AF_INET6;
+				len = 16;
 				goto prefix;
 
 			case AF_LLC:
 				family = AF_LLC;
+				len = 6;
 				goto prefix;
 
 			default:
@@ -449,6 +452,8 @@ prefix:
 
 	if (copy)
 		nl_addr_set_binary_addr(addr, buf, len);
+	else
+		addr->a_len = len;
 
 	if (prefix) {
 		char *p;
@@ -460,7 +465,7 @@ prefix:
 		}
 		nl_addr_set_prefixlen(addr, pl);
 	} else {
-		if (!plen)
+		if (copy && !plen)
 			plen = len * 8;
 		nl_addr_set_prefixlen(addr, plen);
 	}

--- a/lib/addr.c
+++ b/lib/addr.c
@@ -226,7 +226,7 @@ struct nl_addr *nl_addr_build(int family, const void *buf, size_t size)
 		addr->a_prefixlen = size*8;
 	}
 
-	if (size)
+	if (size && buf)
 		memcpy(addr->a_addr, buf, size);
 
 	return addr;

--- a/lib/attr.c
+++ b/lib/attr.c
@@ -541,6 +541,9 @@ int nla_put_data(struct nl_msg *msg, int attrtype, const struct nl_data *data)
  */
 int nla_put_addr(struct nl_msg *msg, int attrtype, struct nl_addr *addr)
 {
+	if (nl_addr_get_len(addr) == 0)
+		return -NLE_INVAL;
+
 	return nla_put(msg, attrtype, nl_addr_get_len(addr),
 		       nl_addr_get_binary_addr(addr));
 }


### PR DESCRIPTION
Default routes (0.0.0.0/0 and ::/0) won't have any data allocated, so
their data length is zero. This causes nla_put_addr() to generate a
zero-length address attribute, which is rightfully rejected by the
kernel.

So in case we we get an address with a zero-length prefix, just allocate
an appropriate sized attribute for the address family. Since nla_reserve
initializes the attribute, we don't need to do anything with it.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>