### PR TITLE
lib: object: Rectify attribute mask logic in 'nl_object_compare()'

### DIFF
--- a/lib/object.c
+++ b/lib/object.c
@@ -338,8 +338,13 @@ int nl_object_identical(struct nl_object *a, struct nl_object *b)
 		req_attrs_b = req_attrs_a;
 	}
 
-	req_attrs_a &= a->ce_mask;
-	req_attrs_b &= b->ce_mask;
+	if (ops->oo_id_attrs_get || ops->oo_id_attrs) {
+		req_attrs_a |= a->ce_mask;
+		req_attrs_b |= b->ce_mask;
+	} else {
+		req_attrs_a &= a->ce_mask;
+		req_attrs_b &= b->ce_mask;
+	}
 
 	/* Both objects must provide all required attributes to uniquely
 	 * identify an object */


### PR DESCRIPTION
Setting of the attribute mask could be narrowed down to two cases:

	1. Object possesses either or both 'oo_id_attrs_get' and
	'oo_id_attrs'
	2. Object lacks both 'oo_id_attrs_get' and 'oo_id_attrs'

In the primary case, one would expect to set, for upcoming comparison,
objects 'ce_mask', to already pre-set required attributes. This would
enable comparison of required attributes together with those set in
the object's 'ce_mask', if such exist.

In the secondary case, with no required attributes in place and 64bit
mask used instead, one would expect to set object's 'ce_mask' and
exclude all other bits. This would enable comparison of only those
attributes defined in the object's 'ce_mask'.

This patch takes care of the above mentioned cases, while previous
behavior would neglect the primary case and never actually compare
any attributes set in the object's 'ce_mask', except the required.

Signed-off-by: Volodymyr Bendiuga <volodymyr.bendiuga@westermo.com>