### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,17 @@ jobs:
             libtool-bin
 
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Lint Python
+        run: |
+          python3 -m pip install flake8
+          flake8 . --count --select=E703,E9,F63,F7,F82,Y --show-source --statistics
 
       - name: Build
         run: |

--- a/doc/doxygen-link.py
+++ b/doc/doxygen-link.py
@@ -11,7 +11,7 @@ rc_script = re.compile(r'\s*(.*\S)?\s*')
 def parse_dict(filename):
 	links = {}
 	for line in open(filename, 'r'):
-		m = re.match('^([^=]+)=([^\n]+)$', line);
+		m = re.match('^([^=]+)=([^\n]+)$', line)
 		if not m:
 			continue
 		name = m.group(1)

--- a/python/examples/iface.py
+++ b/python/examples/iface.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import netlink.capi as nl
 import netlink.genl.capi as genl
 import nl80211
@@ -6,7 +7,7 @@ import traceback
 
 class test_class:
 	def __init__(self):
-		self.done = 1;
+		self.done = 1
 
 def msg_handler(m, a):
 	try:
@@ -16,7 +17,7 @@ def msg_handler(m, a):
 			thiswiphy = nl.nla_get_u32(attr[nl80211.NL80211_ATTR_WIPHY])
 			print("phy#%d" % thiswiphy)
 		if nl80211.NL80211_ATTR_IFNAME in attr:
-			print("\tinterface %s" % nl.nla_get_string(attr[nl80211.NL80211_ATTR_IFNAME]));
+			print("\tinterface %s" % nl.nla_get_string(attr[nl80211.NL80211_ATTR_IFNAME]))
 		if nl80211.NL80211_ATTR_IFINDEX in attr:
 			print("\tifindex %d" % nl.nla_get_u32(attr[nl80211.NL80211_ATTR_IFINDEX]))
 		if nl80211.NL80211_ATTR_WDEV in attr:
@@ -31,7 +32,7 @@ def msg_handler(m, a):
 		if nl80211.NL80211_ATTR_WIPHY_FREQ in attr:
 			freq = nl.nla_get_u32(attr[nl80211.NL80211_ATTR_WIPHY_FREQ])
 
-			sys.stdout.write("\tfreq %d MHz" % freq);
+			sys.stdout.write("\tfreq %d MHz" % freq)
 
 			if nl80211.NL80211_ATTR_CHANNEL_WIDTH in attr:
 				chanw = nl.nla_get_u32(attr[nl80211.NL80211_ATTR_CHANNEL_WIDTH])
@@ -44,13 +45,13 @@ def msg_handler(m, a):
 						nl.nla_get_u32(attr[nl80211.NL80211_ATTR_CENTER_FREQ2]))
 			elif nl80211.NL80211_ATTR_WIPHY_CHANNEL_TYPE in attr:
 				channel_type = nl.nla_get_u32(attr[nl80211.NL80211_ATTR_WIPHY_CHANNEL_TYPE])
-				sys.stdout.write(" %s" % nl80211.nl80211_channel_type2str(channel_type));
+				sys.stdout.write(" %s" % nl80211.nl80211_channel_type2str(channel_type))
 
-			sys.stdout.write("\n");
-		return nl.NL_SKIP;
+			sys.stdout.write("\n")
+		return nl.NL_SKIP
 	except Exception as e:
 		(t,v,tb) = sys.exc_info()
-		print v.message
+		print(v.message)
 		traceback.print_tb(tb)
 
 def error_handler(err, a):
@@ -69,10 +70,10 @@ try:
 	tx_cb = nl.nl_cb_alloc(nl.NL_CB_DEFAULT)
 	rx_cb = nl.nl_cb_clone(tx_cb)
 	s = nl.nl_socket_alloc_cb(tx_cb)
-	nl.py_nl_cb_err(rx_cb, nl.NL_CB_CUSTOM, error_handler, cbd);
-	nl.py_nl_cb_set(rx_cb, nl.NL_CB_FINISH, nl.NL_CB_CUSTOM, finish_handler, cbd);
-	nl.py_nl_cb_set(rx_cb, nl.NL_CB_ACK, nl.NL_CB_CUSTOM, ack_handler, cbd);
-	nl.py_nl_cb_set(rx_cb, nl.NL_CB_VALID, nl.NL_CB_CUSTOM, msg_handler, cbd);
+	nl.py_nl_cb_err(rx_cb, nl.NL_CB_CUSTOM, error_handler, cbd)
+	nl.py_nl_cb_set(rx_cb, nl.NL_CB_FINISH, nl.NL_CB_CUSTOM, finish_handler, cbd)
+	nl.py_nl_cb_set(rx_cb, nl.NL_CB_ACK, nl.NL_CB_CUSTOM, ack_handler, cbd)
+	nl.py_nl_cb_set(rx_cb, nl.NL_CB_VALID, nl.NL_CB_CUSTOM, msg_handler, cbd)
 
 	genl.genl_connect(s)
 	family = genl.genl_ctrl_resolve(s, 'nl80211')
@@ -80,14 +81,14 @@ try:
 	genl.genlmsg_put(m, 0, 0, family, 0, 0, nl80211.NL80211_CMD_GET_INTERFACE, 0)
 	nl.nla_put_u32(m, nl80211.NL80211_ATTR_IFINDEX, nl.if_nametoindex('wlan0'))
 
-	err = nl.nl_send_auto_complete(s, m);
+	err = nl.nl_send_auto_complete(s, m)
 	if err < 0:
-		nl.nlmsg_free(msg)
+		nl.nlmsg_free(m)
 
 	while cbd.done > 0 and not err < 0:
 		err = nl.nl_recvmsgs(s, rx_cb)
 
 except Exception as e:
 	(t, v, tb) = sys.exc_info()
-	print v.message
+	print(v.message)
 	traceback.print_tb(tb)

--- a/python/examples/wiphy.py
+++ b/python/examples/wiphy.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import netlink.capi as nl
 import netlink.genl.capi as genl
 import nl80211
@@ -6,23 +7,23 @@ import traceback
 
 class test_class:
 	def __init__(self):
-		self.done = 1;
+		self.done = 1
 
 def freq_to_ch(freq):
 	if freq == 2484:
-		return 14;
+		return 14
 
 	if freq < 2484:
-		return (freq - 2407) / 5;
+		return (freq - 2407) / 5
 
 	# FIXME: dot11ChannelStartingFactor (802.11-2007 17.3.8.3.2)
 	if freq < 45000:
-		return freq/5 - 1000;
+		return freq/5 - 1000
 
 	if freq >= 58320 and freq <= 64800:
-		return (freq - 56160) / 2160;
+		return (freq - 56160) / 2160
 
-	return 0;
+	return 0
 
 def handle_freq(attr, pol):
 	e, fattr = nl.py_nla_parse_nested(nl80211.NL80211_FREQUENCY_ATTR_MAX, attr, pol)
@@ -83,7 +84,7 @@ def msg_handler(m, a):
 			ciphers = nl.nla_data(attr[nl80211.NL80211_ATTR_CIPHER_SUITES])
 			num = len(ciphers) / 4
 			if num > 0:
-				print("\tSupported Ciphers:");
+				print("\tSupported Ciphers:")
 				for i in range(0, num, 4):
 					print("\t\t* %s" % cipher_name(ciphers[i:i+4]))
 		if nl80211.NL80211_ATTR_SUPPORTED_IFTYPES in attr:
@@ -99,7 +100,7 @@ def msg_handler(m, a):
 		return nl.NL_SKIP
 	except Exception as e:
 		(t,v,tb) = sys.exc_info()
-		print v.message
+		print(v.message)
 		traceback.print_tb(tb)
 
 def error_handler(err, a):
@@ -118,10 +119,10 @@ try:
 	tx_cb = nl.nl_cb_alloc(nl.NL_CB_DEFAULT)
 	rx_cb = nl.nl_cb_clone(tx_cb)
 	s = nl.nl_socket_alloc_cb(tx_cb)
-	nl.py_nl_cb_err(rx_cb, nl.NL_CB_CUSTOM, error_handler, cbd);
-	nl.py_nl_cb_set(rx_cb, nl.NL_CB_FINISH, nl.NL_CB_CUSTOM, finish_handler, cbd);
-	nl.py_nl_cb_set(rx_cb, nl.NL_CB_ACK, nl.NL_CB_CUSTOM, ack_handler, cbd);
-	nl.py_nl_cb_set(rx_cb, nl.NL_CB_VALID, nl.NL_CB_CUSTOM, msg_handler, cbd);
+	nl.py_nl_cb_err(rx_cb, nl.NL_CB_CUSTOM, error_handler, cbd)
+	nl.py_nl_cb_set(rx_cb, nl.NL_CB_FINISH, nl.NL_CB_CUSTOM, finish_handler, cbd)
+	nl.py_nl_cb_set(rx_cb, nl.NL_CB_ACK, nl.NL_CB_CUSTOM, ack_handler, cbd)
+	nl.py_nl_cb_set(rx_cb, nl.NL_CB_VALID, nl.NL_CB_CUSTOM, msg_handler, cbd)
 
 	genl.genl_connect(s)
 	family = genl.genl_ctrl_resolve(s, 'nl80211')
@@ -129,13 +130,13 @@ try:
 	genl.genlmsg_put(m, 0, 0, family, 0, 0, nl80211.NL80211_CMD_GET_WIPHY, 0)
 	nl.nla_put_u32(m, nl80211.NL80211_ATTR_WIPHY, 7)
 
-	err = nl.nl_send_auto_complete(s, m);
+	err = nl.nl_send_auto_complete(s, m)
 	if err < 0:
-		nl.nlmsg_free(msg)
+		nl.nlmsg_free(m)
 
 	while cbd.done > 0 and not err < 0:
 		err = nl.nl_recvmsgs(s, rx_cb)
 except Exception as e:
 	(t, v, tb) = sys.exc_info()
-	print v.message
+	print(v.message)
 	traceback.print_tb(tb)

--- a/python/netlink/core.py
+++ b/python/netlink/core.py
@@ -127,7 +127,7 @@ class Message(object):
         capi.nlmsg_free(self._msg)
 
     def __len__(self):
-        return capi.nlmsg_len(nlmsg_hdr(self._msg))
+        return capi.nlmsg_len(capi.nlmsg_hdr(self._msg))
 
     @property
     def protocol(self):

--- a/python/netlink/route/link.py
+++ b/python/netlink/route/link.py
@@ -40,7 +40,6 @@ __version__ = '0.1'
 __all__ = [
     'LinkCache',
     'Link',
-    'get_from_kernel',
 ]
 
 import socket
@@ -159,7 +158,7 @@ class Link(netlink.Object):
         if exc_type is None:
             self.change()
         else:
-            return false
+            return False
 
     @classmethod
     def from_capi(cls, obj):

--- a/python/netlink/route/links/bridge.py
+++ b/python/netlink/route/links/bridge.py
@@ -7,6 +7,7 @@
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 from ... import core as netlink
 from ..  import capi as capi
@@ -19,10 +20,10 @@ class BRIDGELink(object):
 
     def bridge_assert_ext_info(self):
         if self._has_ext_info == False:
-            print """
+            print("""
             Please update your kernel to be able to call this method.
             Your current kernel bridge version is too old to support this extention.
-            """
+            """)
             raise RuntimeWarning()
 
     def port_state2str(self, state):
@@ -51,12 +52,12 @@ class BRIDGELink(object):
     def priority(self):
         """bridge prio
         """
-        bridge_assert_ext_info()
+        self.bridge_assert_ext_info()
         return capi.rtnl_link_bridge_get_prio(self._link)
 
     @priority.setter
     def priority(self, prio):
-        bridge_assert_ext_info()
+        self.bridge_assert_ext_info()
         if prio < 0 or prio >= 2**16:
             raise ValueError()
         capi.rtnl_link_bridge_set_prio(self._link, int(prio))
@@ -66,12 +67,12 @@ class BRIDGELink(object):
     def cost(self):
         """bridge prio
         """
-        bridge_assert_ext_info()
+        self.bridge_assert_ext_info()
         return capi.rtnl_link_bridge_get_cost(self._link)
 
     @cost.setter
     def cost(self, cost):
-        bridge_assert_ext_info()
+        self.bridge_assert_ext_info()
         if cost < 0 or cost >= 2**32:
             raise ValueError()
         capi.rtnl_link_bridge_set_cost(self._link, int(cost))

--- a/python/netlink/route/links/inet.py
+++ b/python/netlink/route/links/inet.py
@@ -8,9 +8,7 @@
 
 from __future__ import absolute_import
 
-__all__ = [
-    '',
-]
+__all__ = []
 
 from ... import core as netlink
 from ..  import capi as capi

--- a/python/tests/test-create-bridge.py
+++ b/python/tests/test-create-bridge.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import netlink.core as netlink
 import netlink.route.capi as capi
 import netlink.route.link as link
@@ -8,21 +9,21 @@ cache = link.LinkCache()
 cache.refill(sock)
 
 testtap1 = cache['testtap1']
-print testtap1
+print(testtap1)
 
 lbr = link.Link()
 lbr.type = 'bridge'
 lbr.name = 'testbridge'
-print lbr
+print(lbr)
 lbr.add()
 
 cache.refill(sock)
 lbr = cache['testbridge']
-print lbr
+print(lbr)
 
 lbr.enslave(testtap1)
 cache.refill(sock)
 testtap1 = cache['testtap1']
 
-print capi.rtnl_link_is_bridge(lbr._rtnl_link)
-print capi.rtnl_link_get_master(testtap1._rtnl_link)
+print(capi.rtnl_link_is_bridge(lbr._rtnl_link))
+print(capi.rtnl_link_get_master(testtap1._rtnl_link))


### PR DESCRIPTION
Python 2 died 917 days ago on 1/1/2020 so it is no longer available on several modern OS distributions.

Let's update the Python code so it has no Python 3 syntax errors but should still run on Python 2.

~Run [`psf/black`](https://github.com/psf/black#readme) on the three Python examples so they have standard formatting.~ -- Reverted.