### PR TITLE
route/link: prevent segfault in af_request_type()

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -115,7 +115,7 @@ static int af_request_type(int af_type, struct rtnl_link *changes)
 	struct rtnl_link_af_ops *ops;
 
 	ops = rtnl_link_af_ops_lookup(af_type);
-	if (ops && ops->ao_override_rtm(changes))
+	if (ops && ops->ao_override_rtm && ops->ao_override_rtm(changes))
 		return RTM_SETLINK;
 
 	return RTM_NEWLINK;


### PR DESCRIPTION
`ac_request_type()` in `route/link.c` will segfault if the function pointer `ops->ao_override_rtm` has not been initialized for the given `af_type` parameter.

The bug was found while trying to call `rtnl_link_change()` for a link with family type AF_INET6. It seems this bug was introduced in 3c427d0.

Fix: check that `ao_override_rtm` is a valid pointer before calling it. 