### PR TITLE
test-cache-mngr improvements

### DIFF
--- a/tests/test-cache-mngr.c
+++ b/tests/test-cache-mngr.c
@@ -46,6 +46,7 @@ static void change_cb(struct nl_cache *cache, struct nl_object *obj,
 		printf("CHANGE ");
 
 	nl_object_dump(obj, &params);
+	fflush(stdout);
 
 	change = 1;
 }
@@ -174,6 +175,7 @@ int main(int argc, char *argv[])
 
 		if (dump_on_timeout || (dump_on_change && change)) {
 			nl_cache_mngr_info(mngr, &params);
+			fflush(stdout);
 			change = 0;
 		}
 	}


### PR DESCRIPTION
test-cache-mngr is very useful to reproduce and investigate problems in libnl.
This series adds options to tune the behavior of test-cache-mngr. Those
options were used to reproduce various bugs in the version of libnl used in
Cumulus Linux. Except for the last patch, the default behavior remains
unchanged.
