### PR TITLE
libn: Fix set offload capability for MACsec

### DIFF
--- a/lib/route/link/macsec.c
+++ b/lib/route/link/macsec.c
@@ -652,7 +652,7 @@ int rtnl_link_macsec_set_offload(struct rtnl_link *link, uint8_t offload)
 
 	IS_MACSEC_LINK_ASSERT(link);
 
-	if (offload > 1)
+	if (offload > 2)
 		return -NLE_INVAL;
 
 	info->offload = offload;


### PR DESCRIPTION
Currently, rtnl_link_macsec_set_offload rejects any value greater than 1 limiting the MACSEC_ATTR_OFFLOAD attribute to the values 0 and 1 where 2 is also a legal value. Fix by allowing all legal values for MACSEC_ATTR_OFFLOAD.

Fixes: b6cc13d76b29 ("Supporting Hardware offload capability for MACsec")
Signed-off-by: Emeel Hakim <ehakim@nvidia.com>