### PR TITLE
macsec: Fix set offload capability for MACsec

### DIFF
--- a/lib/route/link/macsec.c
+++ b/lib/route/link/macsec.c
@@ -652,9 +652,6 @@ int rtnl_link_macsec_set_offload(struct rtnl_link *link, uint8_t offload)
 
 	IS_MACSEC_LINK_ASSERT(link);
 
-	if (offload > 1)
-		return -NLE_INVAL;
-
 	info->offload = offload;
 	info->ce_mask |= MACSEC_ATTR_OFFLOAD;
 


### PR DESCRIPTION
Update macsec headers in sync with the latest Linux headers and enhance the macsec offload function in the libnl library to enable offloading all types of macsec offload.