### PR TITLE
lib/handlers: add attribute acccess for struct nl_cb cb.cb_refcnt

### DIFF
--- a/include/netlink/handlers.h
+++ b/include/netlink/handlers.h
@@ -117,6 +117,8 @@ extern struct nl_cb *	nl_cb_clone(struct nl_cb *);
 extern struct nl_cb *	nl_cb_get(struct nl_cb *);
 extern void		nl_cb_put(struct nl_cb *);
 
+extern int		nl_cb_get_refcnt(const struct nl_cb *cb);
+
 extern int  nl_cb_set(struct nl_cb *, enum nl_cb_type, enum nl_cb_kind,
 		      nl_recvmsg_msg_cb_t, void *);
 extern int  nl_cb_set_all(struct nl_cb *, enum nl_cb_kind,

--- a/lib/handlers.c
+++ b/lib/handlers.c
@@ -270,6 +270,31 @@ enum nl_cb_type nl_cb_active_type(struct nl_cb *cb)
 /** @} */
 
 /**
+ * @name Attribute Access
+ * @{
+ */
+
+/**
+ * reference counter of callback handle
+ * @arg cb		netlink callback handle
+ *
+ * @returns reference counter of the callback handle
+ * or negative value if @p cb is NULL
+ */
+int nl_cb_get_refcnt(const struct nl_cb *cb)
+{
+	if (!cb)
+		return -1;
+
+	if (cb->cb_refcnt < 0)
+		BUG();
+
+	return cb->cb_refcnt;
+}
+
+/** @} */
+
+/**
  * @name Callback Setup
  * @{
  */


### PR DESCRIPTION
problem:
`nl_cb_put()` decreases the cb.cb_refcnt and if it reaches 0, it will free(cb). `free()` does not set `cb = NULL`, which means that if `cb.cb_refcnt > 1`, we have to call `nl_cb_put()` again until `cb.cb_refcnt = 0`

doing it with, for example, `while(cb) { nl_cb_put(cb); }` won't work becasue `free()` is not doing `cb == NULL` so we never know when `cb_refcnt == 0`.

access to `cb->cb_refcnt` is not possible from outside libnl, one has to
include `libnl/include/netlink-private/types.h` which is not trivial.

solution:
add this function to be able to cleanup properly if `cb.cb_refcnt > 1` so one can do, for example:
`while(cb && nl_cb_get_refcnt(cb) > 0) { nl_cb_put(cb); }`