### PR TITLE
idiag: "fix" license for "idiag-socket-details" tool

### DIFF
--- a/src/idiag-socket-details.c
+++ b/src/idiag-socket-details.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-only */
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (c) 2013 Sassano Systems LLC <joe@sassanosystems.com>
  */


### PR DESCRIPTION
This tool had a GPL-2.0-only license text when it was added. That is not what we expect for libnl3 contributions.

Since being added, the file was only touched by me (Thomas Haller) and Yegor Yefremov. Yegor only added a SPDX license identifier and I am fine that all my (trivial) changes to the file are LGPL-2.0-only compatible.

This leaves only Joe Damato, who initially contributed the file. Joe agrees with this adjustment of the license.

Note that there is also a line:
```
   Copyright (c) 2013 Sassano Systems LLC <joe@sassanosystems.com>
```
I don't know what Sassano Systems says about this. The file seems small enough, to justify this change. It was always a "honest mistake".

The alternative would be to delete the file, which is probably in nobody's interest.

Fixes: c97c8c2bfdb0 ('Add idiag-socket-details')