### PR TITLE
python: Use correct decorator syntax in HTBQdisc

### DIFF
--- a/python/netlink/route/qdisc/htb.py
+++ b/python/netlink/route/qdisc/htb.py
@@ -28,7 +28,7 @@ class HTBQdisc(object):
         capi.rtnl_htb_set_defcls(self._qdisc._rtnl_qdisc, int(value))
 
     @property
-    @netlink.nlattr("r2q", type=int)
+    @netlink.nlattr(type=int)
     def r2q(self):
         return capi.rtnl_htb_get_rate2quantum(self._qdisc._rtnl_qdisc)
 


### PR DESCRIPTION
Fixes: 87d370912ca8 ("netlink.nlattr re-implemented in more pythonic way")