### PR TITLE
Makefile.am: avoid use of non-portable echo arguments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1129,7 +1129,7 @@ EXTRA_DIST += \
 
 %.build-headers-test.c: %
 	mkdir -p "$(dir $@)"
-	echo -e "#include <$$(echo "$<" | sed 's|.*\<include/netlink/|netlink/|')>\nint main(int argc, char **argv) { return 0; }" > $@
+	printf "#include <$$(echo "$<" | sed 's|.*\<include/netlink/|netlink/|')>\nint main(int argc, char **argv) { return 0; }" > $@
 
 %.build-headers-test.o: %.build-headers-test.c
 	$(COMPILE) -Wall -Werror -Wno-error=cpp -I$(srcdir)/include -I$(builddir)/include -c -o $@ $<


### PR DESCRIPTION
This fixes tests with a non-bash shell as /bin/sh (in this case, dash) which does not support `echo -e`. echo itself is portable, but not echo with any arguments.

Use `printf` instead.