### PR TITLE
Unused symbol versioning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -421,7 +421,8 @@ lib_libnl_3_la_CPPFLAGS = \
 	$(lib_cppflags)
 lib_libnl_3_la_LDFLAGS = \
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \
-	-Wl,--version-script=$(srcdir)/libnl-3.sym
+	-Wl,--version-script=$(srcdir)/libnl-3.sym \
+	-Wl,--undefined-version
 
 lib_LTLIBRARIES += lib/libnl-route-3.la
 


### PR DESCRIPTION
I have detected this problem while I was using different linkers for this project.

In this version script file `libnl-3.sym`, a symbol `nl_debug_dp` is defined. However, when doing `./configure --disable-debug`, there is no `nl_debug_dp` variable around, so a symbol is undefined. If the linker is configured to deny unused versions, this is a build error. Building with `ld.bfd` usually succeeds, because its option `--undefined-version` is set by default, while building with `ld.lld` fails because its `--undefined-version` isn't set by default.

This patch fixes this, enabling `--undefined-version` flag for every linker for every build.