### PR TITLE
Allow to allocate cache manager with custom refill socket

### DIFF
--- a/include/netlink/cache.h
+++ b/include/netlink/cache.h
@@ -140,10 +140,15 @@ extern struct nl_cache *	__nl_cache_mngt_require(const char *);
 
 struct nl_cache_mngr;
 
-#define NL_AUTO_PROVIDE		1
-#define NL_ALLOCATED_SOCK	2  /* For internal use only, do not use */
+#define NL_AUTO_PROVIDE		    1
+#define NL_ALLOCATED_SOCK	    2  /* For internal use only, do not use */
+#define NL_ALLOCATED_SYNC_SOCK	4  /* For internal use only, do not use */
 
 extern int			nl_cache_mngr_alloc(struct nl_sock *,
+						    int, int,
+						    struct nl_cache_mngr **);
+extern int			nl_cache_mngr_alloc_ex(struct nl_sock *,
+							struct nl_sock *,
 						    int, int,
 						    struct nl_cache_mngr **);
 extern int			nl_cache_mngr_add(struct nl_cache_mngr *,

--- a/libnl-3.sym
+++ b/libnl-3.sym
@@ -372,3 +372,8 @@ global:
 
 libnl_3_6 {
 } libnl_3_5;
+
+libnl_3_10 {
+global:
+	nl_cache_mngr_alloc_ex;
+} libnl_3_6;


### PR DESCRIPTION
Cache managers use two sockets: one for cache refill operation,
and another one for notifications.

In order to simulate NETLINK events by reading data from files,
we need to be able to overwrite callbacks for both sockets.

This new function allows us to set up refill socket any way we want.
It does have requirement that the refill socket be blocking.