### PR TITLE
cache: fix new object in callback v2 on updated objects

### DIFF
--- a/lib/cache.c
+++ b/lib/cache.c
@@ -808,7 +808,7 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
 			 */
 			if (nl_object_update(old, obj) == 0) {
 				if (cb_v2) {
-					cb_v2(cache, clone, obj, diff,
+					cb_v2(cache, clone, old, diff,
 					      NL_ACT_CHANGE, data);
 					nl_object_put(clone);
 				} else if (cb)


### PR DESCRIPTION
When calling the callback v2 for objects that were updated, we pass the update ("obj") instead of the updated object ("old") as new.

Presumably this wasn't intended, so pass the updated object as new.

This avoids weird updates where the new object is significantly smaller than the old one. E.g. for IPv6 multipath route updates, old would be the full route with all nexthops, while new would be a partial route with only the added/removed nexthop.

Fixes: 66d032ad443a ("cache_mngr: add include callback v2")