### PR TITLE
route: ignore flags and weight of nexthops when doing a strict route comparison

### DIFF
--- a/include/netlink/route/nexthop.h
+++ b/include/netlink/route/nexthop.h
@@ -30,6 +30,9 @@ extern int		rtnl_route_nh_compare(struct rtnl_nexthop *,
 					      struct rtnl_nexthop *,
 					      uint32_t, int);
 
+extern int		rtnl_route_nh_identical(struct rtnl_nexthop *,
+						struct rtnl_nexthop *);
+
 extern void		rtnl_route_nh_dump(struct rtnl_nexthop *,
 					   struct nl_dump_params *);
 

--- a/lib/route/nexthop.c
+++ b/lib/route/nexthop.c
@@ -136,6 +136,23 @@ int rtnl_route_nh_compare(struct rtnl_nexthop *a, struct rtnl_nexthop *b,
 	return diff;
 }
 
+/**
+ * Check if the fixed attributes of two nexthops are identical, and may
+ * only differ in flags or weight.
+ *
+ * @arg a		a nexthop
+ * @arg b		another nexthop
+ *
+ * @return true if both nexthop have equal attributes, otherwise false.
+ */
+int rtnl_route_nh_identical(struct rtnl_nexthop *a, struct rtnl_nexthop *b)
+{
+	return !rtnl_route_nh_compare(a, b,
+				      NH_ATTR_IFINDEX | NH_ATTR_REALMS |
+				      NH_ATTR_GATEWAY | NH_ATTR_NEWDST |
+				      NH_ATTR_VIA | NH_ATTR_ENCAP, 0);
+}
+
 static void nh_dump_line(struct rtnl_nexthop *nh, struct nl_dump_params *dp)
 {
 	struct nl_cache *link_cache;

--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -449,7 +449,7 @@ static uint64_t route_compare(struct nl_object *_a, struct nl_object *_b,
 			found = 0;
 			nl_list_for_each_entry(nh_b, &b->rt_nexthops,
 					       rtnh_list) {
-				if (!rtnl_route_nh_compare(nh_a, nh_b, ~0, 0)) {
+				if (rtnl_route_nh_identical(nh_a, nh_b)) {
 					found = 1;
 					break;
 				}
@@ -464,7 +464,7 @@ static uint64_t route_compare(struct nl_object *_a, struct nl_object *_b,
 			found = 0;
 			nl_list_for_each_entry(nh_a, &a->rt_nexthops,
 					       rtnh_list) {
-				if (!rtnl_route_nh_compare(nh_a, nh_b, ~0, 0)) {
+				if (rtnl_route_nh_identical(nh_a, nh_b)) {
 					found = 1;
 					break;
 				}
@@ -538,7 +538,7 @@ static int route_update(struct nl_object *old_obj, struct nl_object *new_obj)
 		 * Do not add the nexthop to old route if it was already added before
 		 */
 		nl_list_for_each_entry(old_nh, &old_route->rt_nexthops, rtnh_list) {
-			if (!rtnl_route_nh_compare(old_nh, new_nh, ~0, 0)) {
+			if (rtnl_route_nh_identical(old_nh, new_nh)) {
 				return 0;
 			}
 		}
@@ -574,15 +574,7 @@ static int route_update(struct nl_object *old_obj, struct nl_object *new_obj)
 		 */
 		nl_list_for_each_entry(old_nh, &old_route->rt_nexthops,
 			rtnh_list) {
-			/*
-			 * Since the new route has only one nexthop, it's not
-			 * an ECMP route and the nexthop won't have a weight.
-			 * Similarily, the nexthop might have been marked as
-			 * DEAD in its flags if it was deleted.
-			 * Therefore ignore NH_ATTR_FLAGS (= 0x1) and
-			 * NH_ATTR_WEIGHT (= 0x2) while comparing nexthops.
-			 */
-			if (!rtnl_route_nh_compare(old_nh, new_nh, ~0x3, 0)) {
+			if (rtnl_route_nh_identical(old_nh, new_nh)) {
 
 				rtnl_route_remove_nexthop(old_route, old_nh);
 

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1328,4 +1328,5 @@ global:
 	rtnl_link_bridge_set_port_vlan_map_range;
 	rtnl_link_bridge_set_port_vlan_pvid;
 	rtnl_link_bridge_unset_port_vlan_map_range;
+	rtnl_route_nh_identical;
 } libnl_3_9;


### PR DESCRIPTION
When a route is created while the interface has no link, we get a
notification with the route and the nexthop having the flag `LINKDOWN`.

If the interface later gets a link, we do not get a route notification
about it, so the route and nexthop stay at `LINKDOWN` in the libnl cache.

If the route then gets removed again, the to be removed route will not
have the `LINKDOWN` flag anymore, which then can break comparison of the
nexthop(s).

So add a new helper for ignoring FLAGS and WEIGHT for nexthops, and use it
everywhere we want to tell if it's the same nexthop, but not necessarily
in the same state.

For loose comparisons, we still need to use the old function, as else e.g.
route lookup will require specifying exact nexthops, and just filtering for
all routes on a certain interfaces would break.