### PR TITLE
route: add missing priority to route_keygen() debug print

### DIFF
--- a/lib/route/route_obj.c
+++ b/lib/route/route_obj.c
@@ -375,10 +375,11 @@ static void route_keygen(struct nl_object *obj, uint32_t *hashkey,
 
 	*hashkey = nl_hash(rkey, rkey_sz, 0) % table_sz;
 
-	NL_DBG(5, "route %p key (fam %d tos %d table %d addr %s) keysz %d "
-		"hash 0x%x\n", route, rkey->rt_family, rkey->rt_tos,
-		rkey->rt_table, nl_addr2str(addr, buf, sizeof(buf)),
-		rkey_sz, *hashkey);
+	NL_DBG(5,
+	       "route %p key (fam %d tos %d table %d prio %d addr %s) keysz %d hash 0x%x\n",
+	       route, rkey->rt_family, rkey->rt_tos, rkey->rt_table,
+	       rkey->rt_prio, nl_addr2str(addr, buf, sizeof(buf)), rkey_sz,
+	       *hashkey);
 
 	return;
 }


### PR DESCRIPTION
Route priority is part of the hash key calculation, but the debug print omitted it. This could cause seemingly identical values have different hash values.

Fix this by also printing the route priority, and reformat according to .clang-format.


Before:

```
DBG<5>lib/route/route_obj.c:378  route_keygen: route 0x55fd326f7d50 key (fam 10 tos 0 table 254 addr fe80::/64) keysz 26 hash 0x18c
DBG<5>lib/route/route_obj.c:378  route_keygen: route 0x55fd326f7fa0 key (fam 10 tos 0 table 254 addr fe80::/64) keysz 26 hash 0x278
```

After:

```
DBG<5>lib/route/route_obj.c:378  route_keygen: route 0x558cfde91d50 key (fam 10 tos 0 table 254 prio 256 addr fe80::/64) keysz 26 hash 0x18c
DBG<5>lib/route/route_obj.c:378  route_keygen: route 0x558cfde91fa0 key (fam 10 tos 0 table 254 prio 1024 addr fe80::/64) keysz 26 hash 0x278
```

I took the liberty of unbreaking the string, since breaking it can make it harder to grep for and the .clang-format says to not break strings. Even though this one is largely ungreppable with every second word being a format specifier.