### PR TITLE
lib: adjust small time values in _badrandom_from_time

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -67,6 +67,10 @@ static uint32_t _badrandom_from_time(void)
 	time_t t;
 
 	t = time(NULL);
+	/* If a device returns a small time value, increase it to avoid
+	 * returning a value close to the maximum uint32_t value.  */
+	if (t < 1000000000LL)
+		t += 1000000000LL;
 	v64 = (uint64_t)t;
 	result = (uint32_t)v64;
 


### PR DESCRIPTION
On some systems, the clock is reset, or is lost, so the value returned by time can be a very small value. In that case, the _badrandom_from_time function returns a large value close to the maximum uint32_t value. This can be a problem when used to create a sequence number and that number overflows the uint32_t maximum value when it is incremented.

In this case, detect when the time value is too small, and add a value to make sure the value returned is not too close to the uint32_t maximum value.