### PR TITLE
lib: Avoid overflow in computation of s_seq_next.

### DIFF
--- a/lib/nl.c
+++ b/lib/nl.c
@@ -486,7 +486,7 @@ void nl_complete_msg(struct nl_sock *sk, struct nl_msg *msg)
 		nlh->nlmsg_pid = nl_socket_get_local_port(sk);
 
 	if (nlh->nlmsg_seq == NL_AUTO_SEQ)
-		nlh->nlmsg_seq = sk->s_seq_next++;
+		nlh->nlmsg_seq = nl_socket_use_seq(sk);
 
 	if (msg->nm_protocol == -1)
 		msg->nm_protocol = sk->s_proto;

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -24,6 +24,7 @@
 #include "nl-default.h"
 
 #include <fcntl.h>
+#include <limits.h>
 #include <sys/socket.h>
 
 #include <netlink/netlink.h>
@@ -316,6 +317,10 @@ void nl_socket_disable_seq_check(struct nl_sock *sk)
  */
 unsigned int nl_socket_use_seq(struct nl_sock *sk)
 {
+	if (sk->s_seq_next == UINT_MAX) {
+		sk->s_seq_next = 0;
+		return UINT_MAX;
+	}
 	return sk->s_seq_next++;
 }
 


### PR DESCRIPTION
    On some systems, the clock is reset, or is lost, so the value returned
    by the time function can be a very small value. In that case, the
    _badrandom_from_time function returns a large value close to the
    maximum unsigned int value for s_seq_next. This can lead to the value
    wrapping around fairly quickly.
    
    When compiling the library with the unsigned-integer-overflow sanitizer
    enabled, this causes an abort.
    
    Detect this potential wrap around condition and avoid it.