### PR TITLE
link: link_msg_parser(): keep link info instead of release and reacquire

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -681,11 +681,7 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
 					tb[IFLA_PROTINFO] = (struct nlattr *)link->l_af_ops->ao_protinfo_policy;
 			}
 
-			if (link->l_info_ops)
-				release_link_info(link);
-
-			ops = rtnl_link_info_ops_lookup(kind);
-			link->l_info_ops = ops;
+			ops = link->l_info_ops;
 
 			if (ops) {
 				if (ops->io_parse &&


### PR DESCRIPTION
Calling `release_link_info()` will call `io_free()` for `rtnl_link::l_info` was allocated just a few lines before as a side effect of `rtnl_link_set_type()`.

Apart from doing needless memory churn, this will also leave the link with `l_info` set to `NULL` if the link type does not provide a `io_parse()` function.

Assuming the memory leak mentioned in bfee88b8b0a9 ("route: fix memory leak of l_info_ops in link_msg_parser()") was a double reference taken by calling `rtnl_link_info_ops_lookup()` twice, once via `rtnl_link_set_type()`, and once directly, replace the lookup() / release() lookup() with a single lookup() and then reuse the populated `rtnl_link::l_info_ops` pointer.

Fixes: bfee88b8b0a9 ("route: fix memory leak of l_info_ops in link_msg_parser()")