### PR TITLE
lib/attr: add nla functions for variable-length integers

### DIFF
--- a/include/netlink/attr.h
+++ b/include/netlink/attr.h
@@ -47,6 +47,9 @@ enum {
 	NLA_S16,
 	NLA_S32,
 	NLA_S64,
+	/* Skip unimplemented attr types  */
+	NLA_SINT = 20,
+	NLA_UINT,
 	__NLA_TYPE_MAX,
 };
 

--- a/include/netlink/attr.h
+++ b/include/netlink/attr.h
@@ -121,6 +121,10 @@ extern int64_t          nla_get_s64(const struct nlattr *);
 extern int              nla_put_s64(struct nl_msg *, int, int64_t);
 extern uint64_t		nla_get_u64(const struct nlattr *);
 extern int		nla_put_u64(struct nl_msg *, int, uint64_t);
+extern int64_t		nla_get_sint(const struct nlattr *);
+extern int              nla_put_sint(struct nl_msg *, int, int64_t);
+extern uint64_t		nla_get_uint(const struct nlattr *);
+extern int              nla_put_uint(struct nl_msg *, int, uint64_t);
 
 /* String attribute */
 extern char *		nla_get_string(const struct nlattr *);

--- a/lib/attr.c
+++ b/lib/attr.c
@@ -776,6 +776,70 @@ uint64_t nla_get_u64(const struct nlattr *nla)
 	return tmp;
 }
 
+/**
+ * Add variable-length signed integer attribute to netlink message.
+ * @arg msg             Netlink message.
+ * @arg attrtype        Attribute type.
+ * @arg value           Numeric value to store as payload.
+ *
+ * @see nla_put
+ * @return 0 on success or a negative error code.
+ */
+int nla_put_sint(struct nl_msg *msg, int attrtype, int64_t value)
+{
+	int64_t tmp64 = value;
+	int32_t tmp32 = value;
+
+	if (tmp64 == tmp32)
+		return nla_put_s32(msg, attrtype, tmp32);
+	return nla_put(msg, attrtype, sizeof(int64_t), &value);
+}
+
+/**
+ * Return payload of variable-length signed integer attribute
+ * @arg nla		variable-length signed integer attribute
+ *
+ * @return Payload as 64 bit integer.
+ */
+int64_t nla_get_sint(const struct nlattr *nla)
+{
+	if (nla && _nla_len(nla) == sizeof(int32_t))
+		return nla_get_s32(nla);
+	return nla_get_s64(nla);
+}
+
+/**
+ * Add variable-length unsigned integer attribute to netlink message.
+ * @arg msg             Netlink message.
+ * @arg attrtype        Attribute type.
+ * @arg value           Numeric value to store as payload.
+ *
+ * @see nla_put
+ * @return 0 on success or a negative error code.
+ */
+int nla_put_uint(struct nl_msg *msg, int attrtype, uint64_t value)
+{
+	uint64_t tmp64 = value;
+	uint32_t tmp32 = value;
+
+	if (tmp64 == tmp32)
+		return nla_put_u32(msg, attrtype, tmp32);
+	return nla_put(msg, attrtype, sizeof(uint64_t), &value);
+}
+
+/**
+ * Return payload of variable-length unsigned integer attribute
+ * @arg nla		variable-length unsigned integer attribute
+ *
+ * @return Payload as 64 bit integer.
+ */
+uint64_t nla_get_uint(const struct nlattr *nla)
+{
+	if (nla && _nla_len(nla) == sizeof(uint32_t))
+		return nla_get_u32(nla);
+	return nla_get_u64(nla);
+}
+
 /** @} */
 
 /**

--- a/lib/attr.c
+++ b/lib/attr.c
@@ -184,6 +184,8 @@ static uint16_t nla_attr_minlen[NLA_TYPE_MAX+1] = {
 	[NLA_U64]	= sizeof(uint64_t),
 	[NLA_STRING]	= 1,
 	[NLA_FLAG]	= 0,
+	[NLA_SINT]	= sizeof(uint32_t),
+	[NLA_UINT]	= sizeof(uint32_t),
 };
 
 static int validate_nla(const struct nlattr *nla, int maxtype,

--- a/libnl-3.sym
+++ b/libnl-3.sym
@@ -377,3 +377,11 @@ libnl_3_10 {
 global:
 	nl_cache_mngr_alloc_ex;
 } libnl_3_6;
+
+libnl_3_11 {
+global:
+	nla_get_sint;
+	nla_put_sint;
+	nla_get_uint;
+	nla_put_uint;
+} libnl_3_10;


### PR DESCRIPTION
The NLA_{UINT|SINT} attributes[1] are introduced for variable-length integers, whose length are 32bits or 64bits.

So add appropriate functions to get or put NLA_{UINT|SINT} attributes.

[1] https://lore.kernel.org/netdev/20231018213921.2694459-3-kuba@kernel.org/