### PR TITLE
add auto cleanup helper for nl_object and use it

### DIFF
--- a/include/nl-aux-core/nl-core.h
+++ b/include/nl-aux-core/nl-core.h
@@ -50,6 +50,12 @@ void nl_cache_mngr_free(struct nl_cache_mngr *mngr);
 _NL_AUTO_DEFINE_FCN_TYPED0(struct nl_cache_mngr *, _nl_auto_nl_cache_mngr_fcn,
 			   nl_cache_mngr_free);
 
+struct nl_object;
+void nl_object_put(struct nl_object *);
+#define _nl_auto_nl_object _nl_auto(_nl_auto_nl_object_fcn)
+_NL_AUTO_DEFINE_FCN_TYPED0(struct nl_object *, _nl_auto_nl_object_fcn,
+			   nl_object_put);
+
 struct nl_addr *nl_addr_build(int, const void *, size_t);
 
 static inline struct nl_addr *_nl_addr_build(int family, const void *buf)

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -714,17 +714,14 @@ static int __cache_pickup(struct nl_sock *sk, struct nl_cache *cache,
 static int pickup_checkdup_cb(struct nl_object *c, struct nl_parser_param *p)
 {
 	struct nl_cache *cache = (struct nl_cache *)p->pp_arg;
-	struct nl_object *old;
+	_nl_auto_nl_object struct nl_object *old = NULL;
 
 	old = nl_cache_search(cache, c);
 	if (old) {
-		if (nl_object_update(old, c) == 0) {
-			nl_object_put(old);
+		if (nl_object_update(old, c) == 0)
 			return 0;
-		}
 
 		nl_cache_remove(old);
-		nl_object_put(old);
 	}
 
 	return nl_cache_add(cache, c);
@@ -788,8 +785,8 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
 			 struct nl_msgtype *type, change_func_t cb,
 			 change_func_v2_t cb_v2, void *data)
 {
-	struct nl_object *old;
-	struct nl_object *clone = NULL;
+	_nl_auto_nl_object struct nl_object *old = NULL;
+	_nl_auto_nl_object struct nl_object *clone = NULL;
 	uint64_t diff = 0;
 
 	switch (type->mt_act) {
@@ -813,11 +810,8 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
 					nl_object_put(clone);
 				} else if (cb)
 					cb(cache, old, NL_ACT_CHANGE, data);
-				nl_object_put(old);
 				return 0;
 			}
-			nl_object_put(clone);
-
 			nl_cache_remove(old);
 			if (type->mt_act == NL_ACT_DEL) {
 				if (cb_v2)
@@ -825,7 +819,6 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
 					      data);
 				else if (cb)
 					cb(cache, old, NL_ACT_DEL, data);
-				nl_object_put(old);
 			}
 		}
 
@@ -847,7 +840,6 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
 				} else if (diff && cb)
 					cb(cache, obj, NL_ACT_CHANGE, data);
 
-				nl_object_put(old);
 			}
 		}
 		break;

--- a/lib/xfrm/sa.c
+++ b/lib/xfrm/sa.c
@@ -1014,7 +1014,7 @@ static int xfrm_sa_update_cache (struct nl_cache *cache, struct nl_object *obj,
                                  change_func_t change_cb, change_func_v2_t change_cb_v2,
 				 void *data)
 {
-	struct nl_object*       old_sa;
+	_nl_auto_nl_object struct nl_object* old_sa = NULL;
 	struct xfrmnl_sa*       sa = (struct xfrmnl_sa*)obj;
 
 	if (nl_object_get_msgtype (obj) == XFRM_MSG_EXPIRE)
@@ -1064,7 +1064,6 @@ static int xfrm_sa_update_cache (struct nl_cache *cache, struct nl_object *obj,
 					} else if (change_cb)
 						change_cb(cache, obj, NL_ACT_CHANGE, data);
 				}
-				nl_object_put (old_sa);
 			}
 		}
 		else
@@ -1075,7 +1074,6 @@ static int xfrm_sa_update_cache (struct nl_cache *cache, struct nl_object *obj,
 				change_cb_v2(cache, obj, NULL, 0, NL_ACT_DEL, data);
 			else if (change_cb)
 				change_cb (cache, obj, NL_ACT_DEL, data);
-			nl_object_put (old_sa);
 		}
 
 		/* Done handling expire message */


### PR DESCRIPTION
Add a auto cleanup helper for `nl_object`, and use it where appropriate for cache and xfrm.