### PR TITLE
lib/route/link: add support for getting permanent mac address of link.

### DIFF
--- a/doc/route.txt
+++ b/doc/route.txt
@@ -394,6 +394,17 @@ void rtnl_link_set_addr(struct rtnl_link *link, struct nl_addr *addr);
 struct nl_addr *rtnl_link_get_addr(struct rtnl_link *link);
 -----
 
+[[link_attr_permaddr]]
+==== Permanent address
+The permanent link layer address (e.g. MAC address).
+
+[source,c]
+-----
+#include <netlink/route/link.h>
+
+struct nl_addr *rtnl_link_get_perm_addr(struct rtnl_link *link);
+-----
+
 [[link_attr_broadcast]]
 ==== Broadcast Address
 The link layer broadcast address

--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -183,6 +183,8 @@ extern unsigned int rtnl_link_get_arptype(struct rtnl_link *);
 extern void     rtnl_link_set_addr(struct rtnl_link *, struct nl_addr *);
 extern struct nl_addr *rtnl_link_get_addr(struct rtnl_link *);
 
+extern struct nl_addr *rtnl_link_get_perm_addr(struct rtnl_link *);
+
 extern void     rtnl_link_set_broadcast(struct rtnl_link *, struct nl_addr *);
 extern struct nl_addr *rtnl_link_get_broadcast(struct rtnl_link *);
 

--- a/lib/route/nl-route.h
+++ b/lib/route/nl-route.h
@@ -43,6 +43,7 @@ struct rtnl_link {
 	uint32_t l_master;
 	struct nl_addr *l_addr;
 	struct nl_addr *l_bcast;
+	struct nl_addr *l_paddr;
 	char l_qdisc[IFQDISCSIZ];
 	struct rtnl_link_map l_map;
 	uint64_t l_stats[RTNL_LINK_STATS_MAX + 1];

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1340,4 +1340,5 @@ global:
 	rtnl_link_bond_get_miimon;
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
+	rtnl_link_get_perm_addr;
 } libnl_3_10;


### PR DESCRIPTION
Couldn't find any function that gets an interface's permanent mac address (`LINK_ATTR_PERMANENT_ADDR`).

I hope that i did all, or at least most of it, the proper way. My guess is that i forgot to add it (`l_paddr`) on some places...

AFAIK: permanent address can not be changed

Waiting for feedback.

edit: pull request 404 :)