### PR TITLE
lib/route: add rtnl_neigh ext flags support

### DIFF
--- a/include/netlink/route/neighbour.h
+++ b/include/netlink/route/neighbour.h
@@ -36,6 +36,9 @@ extern int	rtnl_neigh_str2state(const char *);
 extern char *	rtnl_neigh_flags2str(int, char *, size_t);
 extern int	rtnl_neigh_str2flag(const char *);
 
+extern char *	rtnl_neigh_extflags2str(uint32_t, char *, size_t);
+extern uint32_t	rtnl_neigh_str2extflag(const char *);
+
 extern int	rtnl_neigh_add(struct nl_sock *, struct rtnl_neigh *, int);
 extern int	rtnl_neigh_build_add_request(struct rtnl_neigh *, int,
 					     struct nl_msg **);
@@ -54,6 +57,13 @@ extern void			rtnl_neigh_set_flags(struct rtnl_neigh *,
 extern void			rtnl_neigh_unset_flags(struct rtnl_neigh *,
 						       unsigned int);
 extern unsigned int		rtnl_neigh_get_flags(struct rtnl_neigh *);
+
+extern void			rtnl_neigh_set_ext_flags(struct rtnl_neigh *,
+							 uint32_t);
+extern void			rtnl_neigh_unset_ext_flags(struct rtnl_neigh *,
+							   uint32_t);
+extern int			rtnl_neigh_get_ext_flags(struct rtnl_neigh *,
+							 uint32_t *);
 
 extern void			rtnl_neigh_set_ifindex(struct rtnl_neigh *,
 						       int);

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1341,4 +1341,9 @@ global:
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
 	rtnl_link_get_perm_addr;
+	rtnl_neigh_extflags2str;
+	rtnl_neigh_get_ext_flags;
+	rtnl_neigh_set_ext_flags;
+	rtnl_neigh_str2extflag;
+	rtnl_neigh_unset_ext_flags;
 } libnl_3_10;


### PR DESCRIPTION
This PR adds support for extended neighbor flags which are sent as an attribute.

A use case for this feature is being able to detect if an FDB entry has the locked flag set.