### PR TITLE
Extend bridge info support

### DIFF
--- a/include/netlink/route/link/bridge_info.h
+++ b/include/netlink/route/link/bridge_info.h
@@ -37,12 +37,21 @@ extern void rtnl_link_bridge_set_vlan_stats_enabled(struct rtnl_link *link,
 						    uint8_t vlan_stats_enabled);
 extern int rtnl_link_bridge_get_vlan_stats_enabled(struct rtnl_link *link,
 						   uint8_t *vlan_stats_enabled);
+
 extern void rtnl_link_bridge_set_nf_call_iptables(struct rtnl_link *link,
 						  uint8_t call_enabled);
+extern int rtnl_link_bridge_get_nf_call_iptables(struct rtnl_link *link,
+						 uint8_t *call_enabled);
+
 extern void rtnl_link_bridge_set_nf_call_ip6tables(struct rtnl_link *link,
 						   uint8_t call_enabled);
+extern int rtnl_link_bridge_get_nf_call_ip6tables(struct rtnl_link *link,
+						  uint8_t *call_enabled);
+
 extern void rtnl_link_bridge_set_nf_call_arptables(struct rtnl_link *link,
 						   uint8_t call_enabled);
+extern int rtnl_link_bridge_get_nf_call_arptables(struct rtnl_link *link,
+						  uint8_t *call_enabled);
 
 #ifdef __cplusplus
 }

--- a/include/netlink/route/link/bridge_info.h
+++ b/include/netlink/route/link/bridge_info.h
@@ -68,6 +68,11 @@ extern void rtnl_link_bridge_set_mcast_snooping(struct rtnl_link *link,
 extern int rtnl_link_bridge_get_mcast_snooping(struct rtnl_link *link,
 					       uint8_t *value);
 
+extern int rtnl_link_bridge_set_boolopt(struct rtnl_link *link, int opt,
+					int value);
+
+extern int rtnl_link_bridge_get_boolopt(struct rtnl_link *link, int opt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/netlink/route/link/bridge_info.h
+++ b/include/netlink/route/link/bridge_info.h
@@ -53,6 +53,21 @@ extern void rtnl_link_bridge_set_nf_call_arptables(struct rtnl_link *link,
 extern int rtnl_link_bridge_get_nf_call_arptables(struct rtnl_link *link,
 						  uint8_t *call_enabled);
 
+extern void rtnl_link_bridge_set_stp_state(struct rtnl_link *link,
+					   uint32_t stp_state);
+extern int rtnl_link_bridge_get_stp_state(struct rtnl_link *link,
+					  uint32_t *stp_state);
+
+extern void rtnl_link_bridge_set_mcast_router(struct rtnl_link *link,
+					      uint8_t type);
+extern int rtnl_link_bridge_get_mcast_router(struct rtnl_link *link,
+					     uint8_t *type);
+
+extern void rtnl_link_bridge_set_mcast_snooping(struct rtnl_link *link,
+						uint8_t value);
+extern int rtnl_link_bridge_get_mcast_snooping(struct rtnl_link *link,
+					       uint8_t *value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/route/link/bridge_info.c
+++ b/lib/route/link/bridge_info.c
@@ -211,6 +211,8 @@ static struct rtnl_link_info_ops bridge_info_ops = {
  * @arg link		Link object of type bridge
  * @arg ageing_time	Interval to set.
  *
+ * @see rtnl_link_bridge_get_ageing_time()
+ *
  * @return void
  */
 void rtnl_link_bridge_set_ageing_time(struct rtnl_link *link,
@@ -458,6 +460,8 @@ int rtnl_link_bridge_get_vlan_stats_enabled(struct rtnl_link *link,
  * @arg link		Link object of type bridge
  * @arg call_enabled	call enabled boolean flag to set.
  *
+ * @see rtnl_link_bridge_get_nf_call_iptables()
+ *
  * @return void
  */
 void rtnl_link_bridge_set_nf_call_iptables(struct rtnl_link *link,
@@ -473,9 +477,40 @@ void rtnl_link_bridge_set_nf_call_iptables(struct rtnl_link *link,
 }
 
 /**
+ * Get call enabled flag for passing IPv4 traffic to iptables
+ * @arg link		Link object of type bridge
+ * @arg call_enabled	Output argument.
+ *
+ * @see rtnl_link_bridge_set_nf_call_iptables()
+ *
+ * @return Zero on success, otherwise a negative error code.
+ * @retval -NLE_NOATTR
+ * @retval -NLE_INVAL
+ */
+int rtnl_link_bridge_get_nf_call_iptables(struct rtnl_link *link,
+					  uint8_t *call_enabled)
+{
+	struct bridge_info *bi = bridge_info(link);
+
+	IS_BRIDGE_INFO_ASSERT(link);
+
+	if (!(bi->ce_mask & BRIDGE_ATTR_NF_CALL_IPTABLES))
+		return -NLE_NOATTR;
+
+	if (!call_enabled)
+		return -NLE_INVAL;
+
+	*call_enabled = bi->b_nf_call_iptables;
+
+	return 0;
+}
+
+/**
  * Set call enabled flag for passing IPv6 traffic to ip6tables
  * @arg link		Link object of type bridge
  * @arg call_enabled	call enabled boolean flag to set.
+ *
+ * @see rtnl_link_bridge_get_nf_call_ip6tables()
  *
  * @return void
  */
@@ -492,9 +527,40 @@ void rtnl_link_bridge_set_nf_call_ip6tables(struct rtnl_link *link,
 }
 
 /**
+ * Get call enabled flag for passing IPv6 traffic to iptables
+ * @arg link		Link object of type bridge
+ * @arg call_enabled	Output argument.
+ *
+ * @see rtnl_link_bridge_set_nf_call_ip6tables()
+ *
+ * @return Zero on success, otherwise a negative error code.
+ * @retval -NLE_NOATTR
+ * @retval -NLE_INVAL
+ */
+int rtnl_link_bridge_get_nf_call_ip6tables(struct rtnl_link *link,
+					   uint8_t *call_enabled)
+{
+	struct bridge_info *bi = bridge_info(link);
+
+	IS_BRIDGE_INFO_ASSERT(link);
+
+	if (!(bi->ce_mask & BRIDGE_ATTR_NF_CALL_IP6TABLES))
+		return -NLE_NOATTR;
+
+	if (!call_enabled)
+		return -NLE_INVAL;
+
+	*call_enabled = bi->b_nf_call_ip6tables;
+
+	return 0;
+}
+
+/**
  * Set call enabled flag for passing ARP traffic to arptables
  * @arg link		Link object of type bridge
  * @arg call_enabled	call enabled boolean flag to set.
+ *
+ * @see rtnl_link_bridge_get_nf_call_arptables()
  *
  * @return void
  */
@@ -508,6 +574,35 @@ void rtnl_link_bridge_set_nf_call_arptables(struct rtnl_link *link,
 	bi->b_nf_call_arptables = call_enabled;
 
 	bi->ce_mask |= BRIDGE_ATTR_NF_CALL_ARPTABLES;
+}
+
+/**
+ * Get call enabled flag for passing ARP traffic to arptables
+ * @arg link		Link object of type bridge
+ * @arg call_enabled	Output argument.
+ *
+ * @see rtnl_link_bridge_set_nf_call_arptables()
+ *
+ * @return Zero on success, otherwise a negative error code.
+ * @retval -NLE_NOATTR
+ * @retval -NLE_INVAL
+ */
+int rtnl_link_bridge_get_nf_call_arptables(struct rtnl_link *link,
+					   uint8_t *call_enabled)
+{
+	struct bridge_info *bi = bridge_info(link);
+
+	IS_BRIDGE_INFO_ASSERT(link);
+
+	if (!(bi->ce_mask & BRIDGE_ATTR_NF_CALL_ARPTABLES))
+		return -NLE_NOATTR;
+
+	if (!call_enabled)
+		return -NLE_INVAL;
+
+	*call_enabled = bi->b_nf_call_arptables;
+
+	return 0;
 }
 
 static void _nl_init bridge_info_init(void)

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1340,12 +1340,14 @@ global:
 	rtnl_link_bond_get_miimon;
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
+	rtnl_link_bridge_get_boolopt;
 	rtnl_link_bridge_get_mcast_router;
 	rtnl_link_bridge_get_mcast_snooping;
 	rtnl_link_bridge_get_nf_call_arptables;
 	rtnl_link_bridge_get_nf_call_ip6tables;
 	rtnl_link_bridge_get_nf_call_iptables;
 	rtnl_link_bridge_get_stp_state;
+	rtnl_link_bridge_set_boolopt;
 	rtnl_link_bridge_set_mcast_router;
 	rtnl_link_bridge_set_mcast_snooping;
 	rtnl_link_bridge_set_stp_state;

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1340,9 +1340,15 @@ global:
 	rtnl_link_bond_get_miimon;
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
+	rtnl_link_bridge_get_mcast_router;
+	rtnl_link_bridge_get_mcast_snooping;
 	rtnl_link_bridge_get_nf_call_arptables;
 	rtnl_link_bridge_get_nf_call_ip6tables;
 	rtnl_link_bridge_get_nf_call_iptables;
+	rtnl_link_bridge_get_stp_state;
+	rtnl_link_bridge_set_mcast_router;
+	rtnl_link_bridge_set_mcast_snooping;
+	rtnl_link_bridge_set_stp_state;
 	rtnl_link_bridge_set_vlan_default_pvid;
 	rtnl_link_get_perm_addr;
 	rtnl_neigh_extflags2str;

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1323,8 +1323,8 @@ global:
 	rtnl_link_bridge_set_ageing_time;
 	rtnl_link_bridge_set_master;
 	rtnl_link_bridge_set_nf_call_arptables;
-	rtnl_link_bridge_set_nf_call_iptables;
 	rtnl_link_bridge_set_nf_call_ip6tables;
+	rtnl_link_bridge_set_nf_call_iptables;
 	rtnl_link_bridge_set_port_vlan_map_range;
 	rtnl_link_bridge_set_port_vlan_pvid;
 	rtnl_link_bridge_unset_port_vlan_map_range;
@@ -1340,6 +1340,9 @@ global:
 	rtnl_link_bond_get_miimon;
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
+	rtnl_link_bridge_get_nf_call_arptables;
+	rtnl_link_bridge_get_nf_call_ip6tables;
+	rtnl_link_bridge_get_nf_call_iptables;
 	rtnl_link_bridge_set_vlan_default_pvid;
 	rtnl_link_get_perm_addr;
 	rtnl_neigh_extflags2str;

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1340,6 +1340,7 @@ global:
 	rtnl_link_bond_get_miimon;
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
+	rtnl_link_bridge_set_vlan_default_pvid;
 	rtnl_link_get_perm_addr;
 	rtnl_neigh_extflags2str;
 	rtnl_neigh_get_ext_flags;


### PR DESCRIPTION
This PR adds a few more supported attributes in route/link/bridge_info.

Support for the following bridge attributes is added:
- IFLA_BR_STP_STATE
- IFLA_BR_MCAST_ROUTER
- IFLA_BR_MCAST_SNOOPING

Support for IFLA_BR_MULTI_BOOLOPT is added, so the following boolopts can be set:
- BR_BOOLOPT_NO_LL_LEARN
- BR_BOOLOPT_MCAST_VLAN_SNOOPING
- BR_BOOLOPT_MST_ENABLE

Additionally, I've added a few missing getter functions for already supported attributes.