### PR TITLE
lib/route: add support for bridge msti

### DIFF
--- a/include/netlink/route/link/bridge.h
+++ b/include/netlink/route/link/bridge.h
@@ -96,6 +96,13 @@ extern int	rtnl_link_bridge_pvid(struct rtnl_link *link);
 extern int	rtnl_link_bridge_has_vlan(struct rtnl_link *link);
 
 extern struct rtnl_link_bridge_vlan *rtnl_link_bridge_get_port_vlan(struct rtnl_link *link);
+
+extern int	rtnl_link_bridge_set_mst_port_state(struct rtnl_link *link, uint16_t instance, uint8_t state);
+extern int	rtnl_link_bridge_get_mst_port_state(struct rtnl_link *link, uint16_t instance);
+extern int	rtnl_link_bridge_del_mst_port_state(struct rtnl_link *link, uint16_t instance);
+extern int	rtnl_link_bridge_clear_mst_port_state_info(struct rtnl_link *link);
+extern int	rtnl_link_bridge_foreach_mst_entry(struct rtnl_link *link, void (*cb)(uint16_t instance, uint8_t state, void *arg), void *arg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1340,9 +1340,13 @@ global:
 	rtnl_link_bond_get_miimon;
 	rtnl_link_bond_get_min_links;
 	rtnl_link_bond_get_mode;
+	rtnl_link_bridge_clear_mst_port_state_info;
+	rtnl_link_bridge_del_mst_port_state;
+	rtnl_link_bridge_foreach_mst_entry;
 	rtnl_link_bridge_get_boolopt;
 	rtnl_link_bridge_get_mcast_router;
 	rtnl_link_bridge_get_mcast_snooping;
+	rtnl_link_bridge_get_mst_port_state;
 	rtnl_link_bridge_get_nf_call_arptables;
 	rtnl_link_bridge_get_nf_call_ip6tables;
 	rtnl_link_bridge_get_nf_call_iptables;
@@ -1350,6 +1354,7 @@ global:
 	rtnl_link_bridge_set_boolopt;
 	rtnl_link_bridge_set_mcast_router;
 	rtnl_link_bridge_set_mcast_snooping;
+	rtnl_link_bridge_set_mst_port_state;
 	rtnl_link_bridge_set_stp_state;
 	rtnl_link_bridge_set_vlan_default_pvid;
 	rtnl_link_get_perm_addr;


### PR DESCRIPTION
This PR adds the ability to set MSTP port states on bridge ports. There a high level API to set up vlan/msti associations yet, so the user would still have to do that part manually until #407 is been finished.