### PR TITLE
route/link: support update operation for link objects

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -1126,6 +1126,20 @@ static void link_keygen(struct nl_object *obj, uint32_t *hashkey,
 	return;
 }
 
+static int link_update(struct nl_object *old_obj, struct nl_object *new_obj)
+{
+	struct rtnl_link *src = (struct rtnl_link *) new_obj;
+	struct rtnl_link *dst = (struct rtnl_link *) old_obj;
+
+	if (!dst->l_af_ops)
+		return -NLE_OPNOTSUPP;
+
+	if (dst->l_af_ops->ao_update)
+		return dst->l_af_ops->ao_update(dst, src);
+
+	return -NLE_OPNOTSUPP;
+}
+
 static uint64_t link_compare(struct nl_object *_a, struct nl_object *_b,
 			     uint64_t attrs, int flags)
 {
@@ -3215,6 +3229,7 @@ static struct nl_object_ops link_obj_ops = {
 	},
 	.oo_compare		= link_compare,
 	.oo_keygen		= link_keygen,
+	.oo_update		= link_update,
 	.oo_attrs2str		= link_attrs2str,
 	.oo_id_attrs		= LINK_ATTR_IFINDEX | LINK_ATTR_FAMILY,
 };

--- a/lib/route/link/link-api.h
+++ b/lib/route/link/link-api.h
@@ -141,6 +141,18 @@ struct rtnl_link_af_ops
 	int		      (*ao_compare)(struct rtnl_link *,
 					    struct rtnl_link *, int, uint32_t, int);
 
+	/**
+	 * Update function
+	 *
+	 * Will be called when af data of the link object given by first argument
+	 * needs to be updated with the af data of the second supplied link object
+	 *
+	 * The function must return 0 for success and error for failure
+	 * to update. In case of failure its assumed that the original
+	 * object is not touched
+	 */
+	int		      (*ao_update)(struct rtnl_link *, struct rtnl_link *);
+
 	/* RTM_NEWLINK override
 	 *
 	 * Called if a change link request is set to the kernel. If this returns


### PR DESCRIPTION
When bridge interfaces are in vlan-aware mode, one of the rtnetlink updates they produce was not handled correctly.

When the set of vlans active on a vlan-aware bridge itself it being changed it produces RTM_NEWLINK message with AF_BRIDGE family (e.g. with `bridge vlan add dev br0 vid 3 self`).
Unlike other messages arriving with AF_BRIDGE family - this one doesn't refer to one of the member interfaces, but to the bridge itself as if it was its own member.

This message doesn't contain full information about bridge - mostly about vlans in IFLA_AF_SPEC attribute. It does, however, refer to the bridge interface itself via ifi_index parameter.

`libnl` parses such message into a link object with `(AF_BRIDGE, br-ifindex)` key.

At the same time, the regular rtnetlink message describing bridge interface itself (one that arrives with AF_UNSPEC family and IFLA_LINKINFO/IFLA_INFO_KIND == bridge) will also be parsed into link object with the same key `(AF_BRIDGE, br-ifindex)`. That is caused by the libnl classifying it internally as bridge (via IFLA_INFO_KIND) and overriding its family to AF_BRIDGE.

Such collision results in an unexpected behavior when we have a cache with the information about bridge (from AF_UNSPEC message) and then receive notification produced by `bridge vlan add/del ... self`. As both link entries have the same key - new one will override the old - and we will have a misleading entry in cache, which doesn't contain most of the information we've had about the bridge. It also defies some established expectations about bridge interfaces in libnl. E.g. `rtnl_link_is_bridge` is 1 for such entries, but `rtnl_link_get_type` is NULL.

This situation can be amended by implementing update mechanism for link objects. With that, it is possible to properly handle such special rtnetlink messages and merge information available in them into full bridge description.

Addresses #377 