### PR TITLE
cache: cache_include(): fix double put for cloned objects

### DIFF
--- a/lib/cache.c
+++ b/lib/cache.c
@@ -807,7 +807,6 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
 				if (cb_v2) {
 					cb_v2(cache, clone, old, diff,
 					      NL_ACT_CHANGE, data);
-					nl_object_put(clone);
 				} else if (cb)
 					cb(cache, old, NL_ACT_CHANGE, data);
 				return 0;


### PR DESCRIPTION
When switching to auto obj, a nl_object_put() was left inplace in cache_include(). This leads to a double reference drop of the cloned object, leading to use after free later or triggering an assert that the reference count went negative.

Fixes: 831e98688a2f ("cache: use the new _nl_auto_nl_object helper")