### PR TITLE
cache: add nl_cache_resync_v2()

### DIFF
--- a/include/netlink/cache.h
+++ b/include/netlink/cache.h
@@ -80,6 +80,10 @@ extern int			nl_cache_resync(struct nl_sock *,
 						struct nl_cache *,
 						change_func_t,
 						void *);
+extern int			nl_cache_resync_v2(struct nl_sock *,
+						   struct nl_cache *,
+						   change_func_v2_t,
+						   void *);
 extern int			nl_cache_include(struct nl_cache *,
 						 struct nl_object *,
 						 change_func_t,

--- a/libnl-3.sym
+++ b/libnl-3.sym
@@ -385,3 +385,8 @@ global:
 	nla_get_uint;
 	nla_put_uint;
 } libnl_3_10;
+
+libnl_3_12 {
+global:
+	nl_cache_resync_v2;
+} libnl_3_11;


### PR DESCRIPTION
When the include callback v2 support was added in 66d032ad443a ("cache_mngr: add include callback v2"), resync_cb() was updated to handle both old and v2 callbacks, but no actual nl_cache_resync_v2() was added to make use of it.

Fix this by adding an appropriate implementation.