### PR TITLE
Fix compilation error in GCC 14

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -23,6 +23,7 @@
 
 #include "nl-default.h"
 
+#include <time.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <sys/socket.h>


### PR DESCRIPTION
lib/socket.c: In function '_badrandom_from_time':
lib/socket.c:70:13: error: implicit declaration of function 'time' [-Wimplicit-function-declaration]
   70 |         t = time(NULL);
      |             ^~~~
lib/socket.c:39:1: note: 'time' is defined in header '<time.h>'; this is probably fixable by adding '#include <time.h>'
   38 | #include "nl-aux-core/nl-core.h"
  +++ |+#include <time.h>
   39 |