### PR TITLE
bridge_info: implement missing rtnl_link_info_ops::io_clone()

### DIFF
--- a/lib/route/link/bridge_info.c
+++ b/lib/route/link/bridge_info.c
@@ -88,6 +88,26 @@ static int bridge_info_alloc(struct rtnl_link *link)
 	return 0;
 }
 
+static int bridge_info_clone(struct rtnl_link *dst, struct rtnl_link *src)
+{
+	struct bridge_info *bi_dst, *bi_src = src->l_info;
+	int err;
+
+	_nl_assert(bi_src);
+
+	err = bridge_info_alloc(dst);
+	if (err)
+		return err;
+
+	bi_dst = dst->l_info;
+
+	_nl_assert(bi_dst);
+
+	*bi_dst = *bi_src;
+
+	return 0;
+}
+
 static int bridge_info_parse(struct rtnl_link *link, struct nlattr *data,
 			     struct nlattr *xstats)
 {
@@ -244,6 +264,7 @@ static void bridge_info_free(struct rtnl_link *link)
 static struct rtnl_link_info_ops bridge_info_ops = {
 	.io_name = "bridge",
 	.io_alloc = bridge_info_alloc,
+	.io_clone = bridge_info_clone,
 	.io_parse = bridge_info_parse,
 	.io_put_attrs = bridge_info_put_attrs,
 	.io_free = bridge_info_free,


### PR DESCRIPTION
Link info ops that use link info also need to implement `rtnl_link_info_ops::io_clone()`, else cloning the link will result in a broken object, and trying to use any `rtnl_link_bridge_*()` accessors will result in a null pointer access due to `rtnl_link::l_info` not being taken over.

So implement the missing `rtnl_link_info_ops::io_clone()` callback.

Fixes: 7391a38e3d5e ("bridge: Add support for link_info of a bridge")