### PR TITLE
link/bonding: add rtnl_link_is_bond() helper

### DIFF
--- a/include/netlink/route/link/bonding.h
+++ b/include/netlink/route/link/bonding.h
@@ -15,6 +15,8 @@ extern "C" {
 
 extern struct rtnl_link *rtnl_link_bond_alloc(void);
 
+extern int	rtnl_link_is_bond(struct rtnl_link *);
+
 extern int	rtnl_link_bond_add(struct nl_sock *, const char *,
 				   struct rtnl_link *);
 

--- a/lib/route/link/bonding.c
+++ b/lib/route/link/bonding.c
@@ -488,6 +488,17 @@ int rtnl_link_bond_add(struct nl_sock *sock, const char *name,
 }
 
 /**
+ * Check if a link is a bond
+ * @arg link		Link object
+ *
+ * @return 1 if the link is a bond, 0 otherwise.
+ */
+int rtnl_link_is_bond(struct rtnl_link *link)
+{
+	return link->l_info_ops == &bonding_info_ops;
+}
+
+/**
  * Add a link to a bond (enslave)
  * @arg sock		netlink socket
  * @arg master		ifindex of bonding master

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1367,5 +1367,6 @@ global:
 
 libnl_3_12 {
 global:
+	rtnl_link_is_bond;
 	rtnl_nh_get_oif;
 } libnl_3_11;


### PR DESCRIPTION
The bonding link type is missing a `rtnl_link_is_*()` helper, so add one to align bonding link type with other link types.