### PR TITLE
ip6_tnl: Add API to mark tunnels to "collect metadata"

### DIFF
--- a/include/netlink/route/link/ip6tnl.h
+++ b/include/netlink/route/link/ip6tnl.h
@@ -48,6 +48,9 @@ extern "C" {
 	extern int rtnl_link_ip6_tnl_set_fwmark(struct rtnl_link *link, uint32_t fwmark);
 	extern int rtnl_link_ip6_tnl_get_fwmark(struct rtnl_link *link, uint32_t *fwmark);
 
+	extern int rtnl_link_ip6_tnl_set_collect_metadata(struct rtnl_link *link, int enable);
+	extern int rtnl_link_ip6_tnl_get_collect_metadata(struct rtnl_link *link, int *enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1367,6 +1367,8 @@ global:
 
 libnl_3_12 {
 global:
+	rtnl_link_ip6_tnl_get_collect_metadata;
+	rtnl_link_ip6_tnl_set_collect_metadata;
 	rtnl_link_is_bond;
 	rtnl_nh_get_oif;
 } libnl_3_11;


### PR DESCRIPTION
To set the flag IFLA_IPTUN_COLLECT_METADATA on the tunnel.