### PR TITLE
lib: avoid overflow in computation of s_seq_expect

### DIFF
--- a/lib/nl.c
+++ b/lib/nl.c
@@ -896,7 +896,10 @@ continue_reading:
 		    hdr->nlmsg_type == NLMSG_OVERRUN) {
 			/* We can't check for !NLM_F_MULTI since some netlink
 			 * users in the kernel are broken. */
-			sk->s_seq_expect++;
+			if (sk->s_seq_expect != UINT_MAX)
+				sk->s_seq_expect++;
+			else
+				sk->s_seq_expect = 0;
 			NL_DBG(3, "recvmsgs(%p): Increased expected " \
 			       "sequence number to %d\n",
 			       sk, sk->s_seq_expect);


### PR DESCRIPTION
On some systems, the clock is reset, or is lost, so the value returned by the time function can be a very small value. In that case, the _badrandom_from_time functions returns a large value close to the maximum unsigned int value for s_seq_expect. This can lead to the value wrapping around fairly quickly.

When compiling the library with the unsigned-integer-overflow sanitizer enabled, this causes an abort.

Detect this potential wrap around condition and avoid it.