### PR TITLE
[th/tests-relax-hz-timers] route/tests: relax check for nh timers

### DIFF
--- a/tests/cksuite-route-nh.c
+++ b/tests/cksuite-route-nh.c
@@ -378,11 +378,13 @@ START_TEST(test_kernel_roundtrip_group_resilient)
 	tmp32 = 0;
 	ck_assert_int_eq(rtnl_nh_get_res_group_idle_timer(grp_kernel, &tmp32),
 			 0);
-	ck_assert_uint_eq(tmp32, 15U);
+	ck_assert_uint_ge(tmp32, 12U);
+	ck_assert_uint_le(tmp32, 15U);
 	tmp32 = 0;
 	ck_assert_int_eq(
 		rtnl_nh_get_res_group_unbalanced_timer(grp_kernel, &tmp32), 0);
-	ck_assert_uint_eq(tmp32, 25U);
+	ck_assert_uint_ge(tmp32, 24U);
+	ck_assert_uint_le(tmp32, 25U);
 }
 END_TEST
 


### PR DESCRIPTION
Kernel stores the timer values internally in HZ size, so it looses precision when converting to HZ and back. And as the HZ value is configurable, it depends on the kernel, how exactly the values get mangled.

Relax the check for that.

https://github.com/thom311/libnl/issues/444