### PR TITLE
lib: fix handling of missing const type qualifiers.

### DIFF
--- a/lib/route/classid.c
+++ b/lib/route/classid.c
@@ -153,7 +153,8 @@ char *rtnl_tc_handle2str(uint32_t handle, char *buf, size_t len)
  */
 int rtnl_tc_str2handle(const char *str, uint32_t *res)
 {
-	char *colon, *end;
+	const char *colon;
+	char *colon2, *end;
 	uint32_t h;
 	int err;
 
@@ -172,7 +173,8 @@ int rtnl_tc_str2handle(const char *str, uint32_t *res)
 		return 0;
 	}
 
-	h = strtoul(str, &colon, 16);
+	h = strtoul(str, &colon2, 16);
+	colon = colon2;
 
 	/* MAJ is not a number */
 	if (colon == str) {

--- a/lib/route/qdisc/netem.c
+++ b/lib/route/qdisc/netem.c
@@ -946,7 +946,7 @@ int rtnl_netem_set_delay_distribution(struct rtnl_qdisc *qdisc, const char *dist
 	char name[NAME_MAX];
 	char dist_suffix[] = ".dist";
 	_nl_auto_free int16_t *data = NULL;
-	char *test_suffix;
+	const char *test_suffix;
 
 	/* Check several locations for the dist file */
 	char *test_path[] = {


### PR DESCRIPTION
For ISO C23, the functions strstr and strpbrk that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

Update to const type for variabkes, as returned string is only used in comparisons which const can be used.

fixes:
```c
../lib/route/classid.c: In function 'rtnl_tc_str2handle':
../lib/route/classid.c:187:37: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  187 |                         if (!(colon = strpbrk(str, ":"))) {
      |                                     ^
../lib/route/qdisc/netem.c: In function 'rtnl_netem_set_delay_distribution':
../lib/route/qdisc/netem.c:961:21: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  961 |         test_suffix = strstr(dist_type, dist_suffix);
      |                     ^
``` 