### PR TITLE
nl-cls-delete: tolerate NLE_OBJ_NOTFOUND from cascaded kernel deletion

### DIFF
--- a/src/nl-cls-delete.c
+++ b/src/nl-cls-delete.c
@@ -54,9 +54,17 @@ static void delete_cb(struct nl_object *obj, void *arg)
 	if (interactive && !nl_cli_confirm(obj, &params, default_yes))
 		return;
 
-	if ((err = rtnl_cls_delete(sock, cls, 0)) < 0)
-		nl_cli_fatal(err, "Unable to delete classifier: %s\n",
-				nl_geterror(err));
+	if ((err = rtnl_cls_delete(sock, cls, 0)) < 0) {
+                if (err == -NLE_OBJ_NOTFOUND) {
+                        if (!quiet) {
+                                printf("Already removed (cascaded) ");
+                                nl_object_dump(obj, &params);
+                        }
+                        return;
+                }
+                nl_cli_fatal(err, "Unable to delete classifier: %s\n",
+                        nl_geterror(err));
+	}
 
 	if (!quiet) {
 		printf("Deleted ");


### PR DESCRIPTION
When deleting a u32 classifier, the kernel cascades the deletion of child objects (hash tables and match rules) when the root node is removed via u32_destroy(). 
Since nl-cls-delete iterates a pre-fetched list of matching entries, subsequent rtnl_cls_delete() calls for already-removed children return -NLE_OBJ_NOTFOUND, which the current code treats as a fatal error.

Handle this by catching NLE_OBJ_NOTFOUND in delete_cb() and treating it as non-fatal. 
These entries are reported as "Already removed (cascaded)" instead of triggering nl_cli_fatal(). The deleted counter only increments for entries that were actively deleted by this tool, not for entries that were already removed by the kernel as a side effect.

Before:
<img width="695" height="247" alt="image" src="https://github.com/user-attachments/assets/514e70d0-c11a-4486-abe9-220ab37e560f" />

After:
<img width="796" height="159" alt="image" src="https://github.com/user-attachments/assets/23597b79-d016-4184-8968-fe5846f1a308" />
